### PR TITLE
Remove `Result` from the public API

### DIFF
--- a/Source/deferred/deferred-extras.swift
+++ b/Source/deferred/deferred-extras.swift
@@ -52,16 +52,6 @@ extension Deferred
   {
     return Mapped<Other>(qos: qos, source: self, transform: transform)
   }
-
-  /// Enqueue a transform to be computed asynchronously after `self` becomes determined.
-  /// - parameter qos: the QOS class at which to execute the transform; defaults to the queue's QOS class.
-  /// - parameter transform: the transform to be performed
-  /// - returns: a `Deferred` reference representing the return value of the transform
-
-  public func map<Other>(qos: DispatchQoS? = nil, transform: @escaping (Value) -> Result<Other>) -> Deferred<Other>
-  {
-    return Mapped<Other>(qos: qos, source: self, transform: transform)
-  }
 }
 
 // MARK: flatMap: asynchronously transform a `Deferred` into another
@@ -126,16 +116,6 @@ extension Deferred
 
 extension Deferred
 {
-  /// Enqueue a transform to be computed asynchronously after `self` and `transform` become determined.
-  /// - parameter qos: the QOS class at which to execute the transform; defaults to the QOS class of this Deferred's queue.
-  /// - parameter transform: the transform to be performed, wrapped in a `Deferred`
-  /// - returns: a `Deferred` reference representing the return value of the transform
-
-  public func apply<Other>(qos: DispatchQoS? = nil, transform: Deferred<(Value) -> Result<Other>>) -> Deferred<Other>
-  {
-    return Applicator<Other>(qos: qos, source: self, transform: transform)
-  }
-
   /// Enqueue a transform to be computed asynchronously after `self` and `transform` become determined.
   /// - parameter qos: the QOS class at which to execute the transform; defaults to the QOS class of this Deferred's queue.
   /// - parameter transform: the transform to be performed, wrapped in a `Deferred`

--- a/Source/deferred/deferred-extras.swift
+++ b/Source/deferred/deferred-extras.swift
@@ -23,7 +23,7 @@ extension Deferred
 
   public func onValue(qos: DispatchQoS? = nil, task: @escaping (Value) -> Void)
   {
-    notify(qos: qos) { if case let .value(v) = $0 { task(v) } }
+    notify(qos: qos) { if let v = $0.value { task(v) } }
   }
 
   // MARK: onError: execute a task when (and only when) a computation fails
@@ -35,7 +35,7 @@ extension Deferred
 
   public func onError(qos: DispatchQoS? = nil, task: @escaping (Error) -> Void)
   {
-    notify(qos: qos) { if case let .error(e) = $0 { task(e) } }
+    notify(qos: qos) { if let e = $0.error { task(e) } }
   }
 }
 

--- a/Source/deferred/deferred.swift
+++ b/Source/deferred/deferred.swift
@@ -312,27 +312,32 @@ open class Deferred<Value>
     return resulto!
   }
 
-  /// Get this `Deferred` value, blocking if necessary until it becomes determined.
-  /// If the `Deferred` is determined by a `Result` in the `.error` state, return nil.
+  /// Get this `Deferred`'s value, blocking if necessary until it becomes determined.
+  /// If the `Deferred` is determined with an `Error`, throw it.
   /// In either case, this property will block until `Deferred` is determined.
   ///
   /// - returns: this `Deferred`'s determined value, or `nil`
 
-  public var value: Value? {
-    if case let .value(v) = result { return v }
-    return nil
+  public func await() throws -> Value
+  {
+    return try result.getValue()
   }
 
-  /// Get this `Deferred` value, blocking if necessary until it becomes determined.
-  /// If the `Deferred` is determined by a `Result` in the `.error` state, return nil.
+  /// Get this `Deferred`'s value, blocking if necessary until it becomes determined.
+  /// If the `Deferred` is determined with an `Error`, return nil.
   /// In either case, this property will block until `Deferred` is determined.
   ///
   /// - returns: this `Deferred`'s determined value, or `nil`
 
-  public var error: Error? {
-    if case let .error(e) = result { return e }
-    return nil
-  }
+  public var value: Value? { return result.value }
+
+  /// Get this `Deferred`'s error, blocking if necessary until it becomes determined.
+  /// If the `Deferred` is determined with a `Value`, return nil.
+  /// In either case, this property will block until `Deferred` is determined.
+  ///
+  /// - returns: this `Deferred`'s determined value, or `nil`
+
+  public var error: Error? { return result.error }
 
   /// Get the quality-of-service class of this `Deferred`'s queue
   /// - returns: the quality-of-service class of this `Deferred`'s queue

--- a/Source/deferred/nsurlsession.swift
+++ b/Source/deferred/nsurlsession.swift
@@ -60,7 +60,7 @@ public class DeferredURLSessionTask<Value>: TBD<Value>
     }
   }
 
-  public override func notify(qos: DispatchQoS? = nil, task: @escaping (Result<Value>) -> Void)
+  public override func notify(qos: DispatchQoS? = nil, task: @escaping (Deferred<Value>) -> Void)
   {
     self.task?.resume()
     self.beginExecution()

--- a/Source/deferred/result.swift
+++ b/Source/deferred/result.swift
@@ -13,12 +13,12 @@ import class Foundation.NSError
 /// The error case does not encode type beyond the Error protocol.
 /// This way there is no need to ever map between error types, which mostly cannot make sense.
 
-public enum Result<Value>: CustomStringConvertible
+enum Result<Value>: CustomStringConvertible
 {
   case value(Value)
   case error(Error)
 
-  public init(task: () throws -> Value)
+  init(task: () throws -> Value)
   {
     do {
       let value = try task()
@@ -29,7 +29,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public init(_ optional: Value?, or error: Error)
+  init(_ optional: Value?, or error: Error)
   {
     switch optional
     {
@@ -38,7 +38,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public var value: Value? {
+  var value: Value? {
     switch self
     {
     case .value(let value): return value
@@ -46,7 +46,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public var isValue: Bool {
+  var isValue: Bool {
     switch self
     {
     case .value: return true
@@ -54,7 +54,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public var error: Error? {
+  var error: Error? {
     switch self
     {
     case .value:            return nil
@@ -62,7 +62,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public var isError: Bool {
+  var isError: Bool {
     switch self
     {
     case .value: return false
@@ -70,7 +70,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public func getValue() throws -> Value
+  func getValue() throws -> Value
   {
     switch self
     {
@@ -80,7 +80,7 @@ public enum Result<Value>: CustomStringConvertible
   }
 
 
-  public var description: String {
+  var description: String {
     switch self
     {
     case .value(let value): return String(describing: value)
@@ -89,7 +89,7 @@ public enum Result<Value>: CustomStringConvertible
   }
 
 
-  public func map<Other>(_ transform: (Value) throws -> Other) -> Result<Other>
+  func map<Other>(_ transform: (Value) throws -> Other) -> Result<Other>
   {
     switch self
     {
@@ -98,7 +98,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public func flatMap<Other>(_ transform: (Value) -> Result<Other>) -> Result<Other>
+  func flatMap<Other>(_ transform: (Value) -> Result<Other>) -> Result<Other>
   {
     switch self
     {
@@ -107,7 +107,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public func apply<Other>(_ transform: Result<(Value) throws -> Other>) -> Result<Other>
+  func apply<Other>(_ transform: Result<(Value) throws -> Other>) -> Result<Other>
   {
     switch self
     {
@@ -122,7 +122,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public func apply<Other>(_ transform: Result<(Value) -> Result<Other>>) -> Result<Other>
+  func apply<Other>(_ transform: Result<(Value) -> Result<Other>>) -> Result<Other>
   {
     switch self
     {
@@ -137,7 +137,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public func recover(_ transform: (Error) -> Result<Value>) -> Result<Value>
+  func recover(_ transform: (Error) -> Result<Value>) -> Result<Value>
   {
     switch self
     {
@@ -147,7 +147,7 @@ public enum Result<Value>: CustomStringConvertible
   }
 }
 
-public func ?? <Value> (possible: Result<Value>, alternate: @autoclosure () -> Value) -> Value
+func ?? <Value> (possible: Result<Value>, alternate: @autoclosure () -> Value) -> Value
 {
   switch possible
   {
@@ -156,7 +156,7 @@ public func ?? <Value> (possible: Result<Value>, alternate: @autoclosure () -> V
   }
 }
 
-public func == <Value: Equatable> (lhr: Result<Value>, rhr: Result<Value>) -> Bool
+func == <Value: Equatable> (lhr: Result<Value>, rhr: Result<Value>) -> Bool
 {
   switch (lhr, rhr)
   {
@@ -171,12 +171,12 @@ public func == <Value: Equatable> (lhr: Result<Value>, rhr: Result<Value>) -> Bo
   }
 }
 
-public func != <Value: Equatable> (lhr: Result<Value>, rhr: Result<Value>) -> Bool
+func != <Value: Equatable> (lhr: Result<Value>, rhr: Result<Value>) -> Bool
 {
   return !(lhr == rhr)
 }
 
-public func == <C: Collection, Value: Equatable> (lha: C, rha: C) -> Bool
+func == <C: Collection, Value: Equatable> (lha: C, rha: C) -> Bool
   where C.Iterator.Element == Result<Value>
 {
   guard lha.count == rha.count else { return false }
@@ -189,7 +189,7 @@ public func == <C: Collection, Value: Equatable> (lha: C, rha: C) -> Bool
   return true
 }
 
-public func != <C: Collection, Value: Equatable> (lha: C, rha: C) -> Bool
+func != <C: Collection, Value: Equatable> (lha: C, rha: C) -> Bool
   where C.Iterator.Element == Result<Value>
 {
   return !(lha == rha)

--- a/Source/deferred/waiter.swift
+++ b/Source/deferred/waiter.swift
@@ -11,29 +11,29 @@ import Dispatch
 struct Waiter<T>
 {
   private let qos: DispatchQoS?
-  private let handler: (Result<T>) -> Void
+  private let handler: () -> Void
   var next: UnsafeMutablePointer<Waiter<T>>? = nil
 
-  init(_ qos: DispatchQoS? = nil, _ handler: @escaping (Result<T>) -> Void)
+  init(_ qos: DispatchQoS? = nil, _ handler: @escaping () -> Void)
   {
     self.qos = qos
     self.handler = handler
   }
 
-  fileprivate func notify(_ queue: DispatchQueue, _ result: Result<T>)
+  fileprivate func notify(_ queue: DispatchQueue)
   {
-    queue.async(qos: qos) { [ handler = self.handler ] in handler(result) }
+    queue.async(qos: qos) { [ handler = self.handler ] in handler() }
   }
 }
 
-func notifyWaiters<T>(_ queue: DispatchQueue, _ tail: UnsafeMutablePointer<Waiter<T>>?, _ result: Result<T>)
+func notifyWaiters<T>(_ queue: DispatchQueue, _ tail: UnsafeMutablePointer<Waiter<T>>?)
 {
   var head = reverseList(tail)
   while let current = head
   {
     head = current.pointee.next
 
-    current.pointee.notify(queue, result)
+    current.pointee.notify(queue)
 
     current.deinitialize(count: 1)
     current.deallocate(capacity: 1)

--- a/Tests/deferredTests/DeferredCombinationTests.swift
+++ b/Tests/deferredTests/DeferredCombinationTests.swift
@@ -191,20 +191,17 @@ class DeferredCombinationTests: XCTestCase
 
     deferreds.forEach {
       d in
-      switch d.result
-      {
-      case .value(let value):
+      do {
+        let value = try d.await()
         XCTAssert(value == lucky)
-      case .error(let error as DeferredError):
-        XCTAssert(error == DeferredError.canceled(""))
-      case .error(let error):
-        XCTFail("Wrong error: \(error)")
       }
+      catch DeferredError.canceled(let s) { XCTAssert(s == "") }
+      catch { XCTFail("Wrong error: \(error)") }
     }
 
     let never = firstValue(EmptyIterator<Deferred<Any>>())
     do {
-      _ = try never.result.getValue()
+      _ = try never.await()
       XCTFail()
     }
     catch DeferredError.canceled(let s) { XCTAssert(s != "") }
@@ -276,13 +273,11 @@ class DeferredCombinationTimedTests: XCTestCase
       let inputs = (1...iterations).map { Deferred(value: $0) }
       self.startMeasuring()
       let c = reduce(inputs, initial: 0, combine: +)
-      switch c.result
-      {
-      case .value(let v):
+      do {
+        let v = try c.await()
         XCTAssert(v == (iterations*(iterations+1)/2))
-      default:
-        XCTFail()
       }
+      catch { XCTFail() }
       self.stopMeasuring()
     }
   }
@@ -301,13 +296,11 @@ class DeferredCombinationTimedTests: XCTestCase
           u in deferred.map { t in u+t }
         }
       }
-      switch c.result
-      {
-      case .value(let v):
+      do {
+        let v = try c.await()
         XCTAssert(v == (iterations*(iterations+1)/2))
-      default:
-        XCTFail()
       }
+      catch { XCTFail() }
       self.stopMeasuring()
     }
   }
@@ -320,13 +313,11 @@ class DeferredCombinationTimedTests: XCTestCase
       let inputs = (1...iterations).map { Deferred(value: $0) }
       self.startMeasuring()
       let c = combine(inputs)
-      switch c.result
-      {
-      case .value(let v):
+      do {
+        let v = try c.await()
         XCTAssert(v.count == iterations)
-      default:
-        XCTFail()
       }
+      catch { XCTFail() }
       self.stopMeasuring()
     }
   }

--- a/Tests/deferredTests/DeferredCombinationTests.swift
+++ b/Tests/deferredTests/DeferredCombinationTests.swift
@@ -38,9 +38,9 @@ class DeferredCombinationTests: XCTestCase
     }
     c.notify { _ in e.fulfill() }
 
-    XCTAssert(c.result.isValue == false)
-    XCTAssert(c.result.isError)
-    if let error = c.result.error as? TestError
+    XCTAssert(c.value == nil)
+    XCTAssert(c.error != nil)
+    if let error = c.error as? TestError
     {
       XCTAssert(error.error >= 9)
     }

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -35,14 +35,12 @@ class DeferredTests: XCTestCase
     ("testNotify3", testNotify3),
     ("testNotify4", testNotify4),
     ("testMap", testMap),
-    ("testMap2", testMap2),
     ("testRecover", testRecover),
     ("testRetry", testRetry),
     ("testFlatMap", testFlatMap),
     ("testApply", testApply),
     ("testApply1", testApply1),
     ("testApply2", testApply2),
-    ("testApply3", testApply3),
     ("testQoS", testQoS),
     ("testCancel", testCancel),
     ("testCancelAndNotify", testCancelAndNotify),
@@ -83,11 +81,11 @@ class DeferredTests: XCTestCase
     let result5 = result2.map(transform: Double.init).timeout(.milliseconds(50))
 
     syncprint("Waiting")
-    syncprint("Result 1: \(result1.result)")
-    syncprint("Result 2: \(result2.result)")
-    syncprint("Result 3: \(result3.result)")
-    syncprint("Result 4: \(result4.result)")
-    syncprint("Result 5: \(result5.result)")
+    syncprint("Result 1: \(result1.value!)")
+    syncprint("Result 2: \(result2.value!)")
+    syncprint("Result 3: \(result3.value!)")
+    syncprint("Result 4: \(result4.value!)")
+    syncprint("Result 5: \(result5.error!)")
     syncprint("Done")
     syncprintwait()
 
@@ -118,7 +116,7 @@ class DeferredTests: XCTestCase
 
   func testDelay()
   {
-    let d = Deferred(Result.value(Date()))
+    let d = Deferred(value: Date())
 
     let t1 = 0.05
     let d1 = d.delay(seconds: t1).map { Date().timeIntervalSince($0) }
@@ -166,20 +164,20 @@ class DeferredTests: XCTestCase
     XCTAssert(d.isDetermined)
   }
 
-  func testPeek()
+  func testPeek() throws
   {
     let value = 1
     let d1 = Deferred(value: value)
-    XCTAssert(d1.peek()! == Result.value(value))
+    try XCTAssert(d1.peek()! == value)
 
     let d2 = d1.delay(.microseconds(10_000))
-    XCTAssert(d2.peek() == nil)
+    try XCTAssert(d2.peek() == nil)
     XCTAssert(d2.isDetermined == false)
 
     _ = d2.value // Wait for delay
 
-    XCTAssert(d2.peek() != nil)
-    XCTAssert(d2.peek()! == Result.value(value))
+    try XCTAssert(d2.peek() != nil)
+    try XCTAssert(d2.peek()! == value)
     XCTAssert(d2.isDetermined)
   }
 
@@ -335,29 +333,6 @@ class DeferredTests: XCTestCase
     XCTAssert(d3.error as? TestError == TestError(error))
   }
 
-  func testMap2()
-  {
-    let value = nzRandom()
-    let error = nzRandom()
-    let goodOperand = Deferred(value: value)
-    let badOperand  = Deferred<Double>(error: TestError(error))
-
-    // good operand, good transform
-    let d1 = goodOperand.map { Result.value(Int($0)*2) }
-    XCTAssert(d1.value == Int(value)*2)
-    XCTAssert(d1.error == nil)
-
-    // good operand, transform errors
-    let d2 = goodOperand.map { Result<Void>.error(TestError($0)) }
-    XCTAssert(d2.value == nil)
-    XCTAssert(d2.error as? TestError == TestError(value))
-
-    // bad operand, transform short-circuited
-    let d3 = badOperand.map { _ in Result<Void> { XCTFail() } }
-    XCTAssert(d3.value == nil)
-    XCTAssert(d3.error as? TestError == TestError(error))
-  }
-
   func testRecover()
   {
     let value = nzRandom()
@@ -385,12 +360,11 @@ class DeferredTests: XCTestCase
     let d4 = goodOperand.delay(.milliseconds(50))
     let r4 = d4.recover { e in Deferred(value: value) }
     XCTAssert(r4.cancel(reason))
-    do {
-      _ = try r4.result.getValue()
-      XCTFail()
-    }
-    catch DeferredError.canceled(let message) { XCTAssert(message == reason) }
-    catch { XCTFail() }
+    XCTAssert(r4.value == nil)
+    if let e = r4.error as? DeferredError,
+       case .canceled(let message) = e
+    { XCTAssert(message == reason) }
+    else { XCTFail() }
   }
 
   func testRetry()
@@ -478,7 +452,7 @@ class DeferredTests: XCTestCase
     XCTAssert(result.value == powf(v3.value!, v4.value!))
   }
 
-  func testApply1()
+  func testApply1() throws
   {
     let transform = TBD<(Int) -> Double>()
     let operand = TBD<Int>()
@@ -506,9 +480,9 @@ class DeferredTests: XCTestCase
       operand.determine(v2)
     }
 
-    XCTAssert(operand.peek() == nil)
+    try XCTAssert(operand.peek() == nil)
     XCTAssert(operand.state == .waiting)
-    XCTAssert(transform.peek() == nil)
+    try XCTAssert(transform.peek() == nil)
     XCTAssert(transform.state == .waiting)
 
     g.determine(0)
@@ -543,32 +517,6 @@ class DeferredTests: XCTestCase
     waitForExpectations(timeout: 1.0)
   }
 
-  func testApply3()
-  {
-    let value = Int(nzRandom() & 0x7fff + 10000)
-    let error = nzRandom()
-
-    // good operand, good transform
-    let o1 = Deferred(value: value)
-    let t1 = Deferred { i in Result.value(Double(value*i)) }
-    let e1 = expectation(description: "r1")
-    let r1 = o1.apply(transform: t1)
-    r1.notify { _ in e1.fulfill() }
-    XCTAssert(r1.value == Double(value*value))
-    XCTAssert(r1.error == nil)
-
-    // bad operand, transform not applied
-    let o2 = Deferred<Int> { throw TestError(error) }
-    let t2 = Deferred { (i:Int) in Result<Float> { XCTFail(); return Float(i) } }
-    let e2 = expectation(description: "r2")
-    let r2 = o2.apply(transform: t2)
-    r2.notify { _ in e2.fulfill() }
-    XCTAssert(r2.value == nil)
-    XCTAssert(r2.error as? TestError == TestError(error))
-
-    waitForExpectations(timeout: 1.0)
-  }
-
   func testQoS()
   {
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
@@ -579,7 +527,7 @@ class DeferredTests: XCTestCase
     XCTAssert(qb.qos == DispatchQoS.background)
 
     let e1 = expectation(description: "e1")
-    let q1 = Deferred(qos: .background, result: Result.value(qos_class_self()))
+    let q1 = Deferred(qos: .background, value: qos_class_self())
     q1.onValue {
       qosv in
       // Verify that the QOS has been adjusted
@@ -687,7 +635,7 @@ class DeferredTests: XCTestCase
     XCTAssert(d1.cancel() == true)
 
     let e2 = expectation(description: "cancellation of Deferred.map(_: U -> Result<T>)")
-    let d2 = tbd.map { u in Result.value(XCTFail(String(u))) }
+    let d2 = tbd.map { u in XCTFail(String(u)) }
     d2.onError { e in e2.fulfill() }
     XCTAssert(d2.cancel() == true)
 
@@ -747,7 +695,7 @@ class DeferredTests: XCTestCase
     XCTAssert(d2.cancel() == true)
 
     let e3 = expectation(description: "cancellation of Deferred.apply, part 3")
-    let t3 = Deferred { (i: Int) in Result.value(Double(i)) }
+    let t3 = Deferred { (i: Int) in Double(i) }
     let d3 = tbd.apply(transform: t3)
     d3.onError { e in e3.fulfill() }
     XCTAssert(d3.cancel() == true)

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -250,7 +250,7 @@ class DeferredTests: XCTestCase
     let e1 = expectation(description: "Pre-set Deferred")
     let d1 = Deferred(value: value)
     d1.notify {
-      XCTAssert( $0 == Result.value(value) )
+      XCTAssert( $0.value == value )
       e1.fulfill()
     }
     waitForExpectations(timeout: 1.0)
@@ -265,7 +265,7 @@ class DeferredTests: XCTestCase
     let q3 = DispatchQueue(label: "Test", qos: .background)
     let d3 = d2.notifying(on: q3)
     d3.notify(qos: .utility) {
-      XCTAssert( $0 == Result.value(value) )
+      XCTAssert( $0.value == value )
       e2.fulfill()
     }
     waitForExpectations(timeout: 1.0)
@@ -280,8 +280,8 @@ class DeferredTests: XCTestCase
       return 42
     }
     d3.notify {
-      result in
-      guard case let .error(e) = result,
+      deferred in
+      guard let e = deferred.error,
             let deferredErr = e as? DeferredError,
             case .canceled = deferredErr
       else
@@ -488,9 +488,9 @@ class DeferredTests: XCTestCase
     var v1 = 0
     var v2 = 0
     result.notify {
-      result in
+      deferred in
       print("\(v1), \(v2), \(result)")
-      XCTAssert(result == Result.value(Double(v1*v2)))
+      XCTAssert(deferred.value == Double(v1*v2))
       expect.fulfill()
     }
 

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -29,6 +29,7 @@ class DeferredTests: XCTestCase
     ("testPeek", testPeek),
     ("testValueBlocks", testValueBlocks),
     ("testValueUnblocks", testValueUnblocks),
+    ("testAwait", testAwait),
     ("testOptional", testOptional),
     ("testNotify1", testNotify1),
     ("testNotify2", testNotify2),
@@ -242,6 +243,23 @@ class DeferredTests: XCTestCase
     }
 
     waitForExpectations(timeout: 2.0)
+  }
+
+  func testAwait()
+  {
+    let e = TestError(1)
+    let d1 = Deferred(value: 1.0)
+    let d2 = d1.map(transform: { _  throws -> Double in throw e})
+    var double = Optional<Double>.none
+    do {
+      double = try d1.await()
+      double = try d2.await()
+      XCTFail()
+    } catch let error as TestError {
+      XCTAssert(error == e)
+    } catch { XCTFail() }
+
+    XCTAssert(double == 1.0)
   }
 
   func testNotify1()

--- a/Tests/deferredTests/DeletionTests.swift
+++ b/Tests/deferredTests/DeletionTests.swift
@@ -17,6 +17,7 @@ class DeletionTests: XCTestCase
   static var allTests = [
     ("testDeallocDeferred1", testDeallocDeferred1),
     ("testDeallocDeferred2", testDeallocDeferred2),
+    ("testDelayedDeallocDeferred", testDelayedDeallocDeferred),
     ("testDeallocTBD1", testDeallocTBD1),
     ("testDeallocTBD2", testDeallocTBD2),
   ]
@@ -52,6 +53,21 @@ class DeletionTests: XCTestCase
     }
 
     waitForExpectations(timeout: 0.1)
+  }
+
+  func testDelayedDeallocDeferred()
+  {
+    let witness: Deferred<Void>
+    let e = expectation(description: "deallocation delay")
+    do {
+      let queue = DispatchQueue(label: "\(#function)")
+      let delayed = Deferred(queue: queue, value: ()).delay(.milliseconds(50))
+      _ = delayed.map { XCTFail("a value no one waits for should not be computed") }
+      witness = delayed.map { e.fulfill() }
+    }
+
+    waitForExpectations(timeout: 0.5)
+    _ = witness.value
   }
 
   class DeallocTBD: TBD<Void>

--- a/Tests/deferredTests/DeletionTests.swift
+++ b/Tests/deferredTests/DeletionTests.swift
@@ -39,8 +39,7 @@ class DeletionTests: XCTestCase
   func testDeallocDeferred1()
   {
     do {
-      let deferred = Dealloc(expectation: expectation(description: "will dealloc deferred 1"))
-      do { deferred.notify { _ in XCTFail("Unexpected notification") } }
+      _ = Dealloc(expectation: expectation(description: "will dealloc deferred 1"))
     }
 
     waitForExpectations(timeout: 0.1)
@@ -49,7 +48,18 @@ class DeletionTests: XCTestCase
   func testDeallocDeferred2()
   {
     do {
-      Dealloc(expectation: expectation(description: "will dealloc deferred 2")).cancel()
+      let deferred = Dealloc(expectation: expectation(description: "will dealloc deferred 2"))
+      do { _ = deferred.map { _ in XCTFail("Unexpected notification") } }
+      deferred.cancel()
+    }
+
+    waitForExpectations(timeout: 0.1)
+  }
+
+  func testDeallocDeferred3()
+  {
+    do {
+      Dealloc(expectation: expectation(description: "will dealloc deferred 3")).cancel()
     }
 
     waitForExpectations(timeout: 0.1)
@@ -87,8 +97,7 @@ class DeletionTests: XCTestCase
   func testDeallocTBD1()
   {
     do {
-      let tbd = DeallocTBD(expectation: expectation(description: "will dealloc tbd 1"))
-      do { tbd.notify { _ in XCTFail("Unexpected notification") } }
+      _ = DeallocTBD(expectation: expectation(description: "will dealloc tbd 1"))
     }
 
     waitForExpectations(timeout: 0.1)
@@ -97,7 +106,18 @@ class DeletionTests: XCTestCase
   func testDeallocTBD2()
   {
     do {
-      DeallocTBD(expectation: expectation(description: "will dealloc tbd 2")).cancel()
+      let tbd = DeallocTBD(expectation: expectation(description: "will dealloc tbd 2"))
+      do { _ = tbd.map { _ in XCTFail("Unexpected notification") } }
+      tbd.cancel()
+    }
+
+    waitForExpectations(timeout: 0.1)
+  }
+
+  func testDeallocTBD3()
+  {
+    do {
+      DeallocTBD(expectation: expectation(description: "will dealloc tbd 3")).cancel()
     }
 
     waitForExpectations(timeout: 0.1)

--- a/Tests/deferredTests/TBDTests.swift
+++ b/Tests/deferredTests/TBDTests.swift
@@ -121,7 +121,7 @@ class TBDTests: XCTestCase
     tbd.determine(value)
 
     tbd.notify {
-      XCTAssert( $0 == Result.value(value) )
+      XCTAssert( $0.value == value )
       e1.fulfill()
     }
     waitForExpectations(timeout: 1.0)
@@ -134,7 +134,7 @@ class TBDTests: XCTestCase
 
     var value = nzRandom()
     tbd.notify {
-      XCTAssert( $0 == Result.value(value) )
+      XCTAssert( $0.value == value )
       e2.fulfill()
     }
 
@@ -151,9 +151,9 @@ class TBDTests: XCTestCase
     let e3 = expectation(description: "TBD never determined")
     let d3 = TBD<Int>()
     d3.notify {
-      result in
+      deferred in
       do {
-        _ = try result.getValue()
+        _ = try deferred.result.getValue()
         XCTFail()
       }
       catch DeferredError.canceled {}
@@ -232,8 +232,8 @@ class TBDTests: XCTestCase
     let d = Deferred.inParallel(count: count, queue: q) { $0 }
     let c = combine(d)
     c.notify {
-      r in
-      switch r
+      deferred in
+      switch deferred.result
       {
       case .value(let value):
         XCTAssert(value.count == count)

--- a/Tests/deferredTests/TBDTimingTests.swift
+++ b/Tests/deferredTests/TBDTimingTests.swift
@@ -41,16 +41,13 @@ class TBDTimingTests: XCTestCase
 
       first.determine( (0, ref, ref) )
 
-      switch dt.result
-      {
-      case let .value(iterations, tic, toc):
+      do {
+        let (iterations, tic, toc) = try dt.await()
         let interval = toc.timeIntervalSince(tic)
         // print("\(round(Double(interval*1e9)/Double(iterations))/1000) µs per message")
         _ = interval/Double(iterations)
-        break
-
-      default: XCTFail()
       }
+      catch { XCTFail() }
     }
   }
 
@@ -68,15 +65,12 @@ class TBDTimingTests: XCTestCase
       let dt = start.map { start in Date().timeIntervalSince(start) }
       start.determine(Date())
 
-      switch dt.result
-      {
-      case .value(let interval):
+      do {
+        let interval = try dt.await()
         // print("\(round(Double(interval*1e9)/Double(iterations))/1000) µs per notification")
         _ = interval
-        break
-
-      default: XCTFail()
       }
+      catch { XCTFail() }
     }
   }
 }

--- a/Tests/deferredTests/TestError.swift
+++ b/Tests/deferredTests/TestError.swift
@@ -6,21 +6,10 @@
 //  Copyright © 2015 Guillaume Lessard. All rights reserved.
 //
 
-import enum deferred.Result
-
 struct TestError: Error, Equatable
 {
   let error: Int
   init(_ e: Int = 0) { error = e }
-
-  func matches<T>(_ result: Result<T>) -> Bool
-  {
-    if let e = result.error as? TestError
-    {
-      return self == e
-    }
-    return false
-  }
 }
 
 func == (l: TestError, r: TestError) -> Bool


### PR DESCRIPTION
…in a fuller embrace of the Swift error-handling model.