### PR TITLE
Remove Result from the public API

### DIFF
--- a/Source/deferred/deferred-combine.swift
+++ b/Source/deferred/deferred-combine.swift
@@ -211,12 +211,7 @@ public func firstDetermined<Value, C: Collection>(qos: DispatchQoS = DispatchQoS
 
   deferreds.forEach {
     deferred in
-    deferred.notify {
-      _ in
-      // an error here just means `deferred` wasn't the first to become determined
-      first.determine(deferred)
-    }
-
+    deferred.notify { first.determine($0) }
     if cancelOthers { first.notify { _ in deferred.cancel() } }
   }
 
@@ -236,12 +231,7 @@ public func firstDetermined<Value, S: Sequence>(qos: DispatchQoS = DispatchQoS.c
     deferreds.forEach {
       deferred in
       subscribed = true
-      deferred.notify {
-        _ in
-        // an error here just means `deferred` wasn't the first to become determined
-        first.determine(deferred)
-      }
-
+      deferred.notify { first.determine($0) }
       if cancelOthers { first.notify { _ in deferred.cancel() } }
     }
 

--- a/Source/deferred/deferred-extras.swift
+++ b/Source/deferred/deferred-extras.swift
@@ -52,16 +52,6 @@ extension Deferred
   {
     return Mapped<Other>(qos: qos, source: self, transform: transform)
   }
-
-  /// Enqueue a transform to be computed asynchronously after `self` becomes determined.
-  /// - parameter qos: the QOS class at which to execute the transform; defaults to the queue's QOS class.
-  /// - parameter transform: the transform to be performed
-  /// - returns: a `Deferred` reference representing the return value of the transform
-
-  public func map<Other>(qos: DispatchQoS? = nil, transform: @escaping (Value) -> Result<Other>) -> Deferred<Other>
-  {
-    return Mapped<Other>(qos: qos, source: self, transform: transform)
-  }
 }
 
 // MARK: flatMap: asynchronously transform a `Deferred` into another
@@ -126,16 +116,6 @@ extension Deferred
 
 extension Deferred
 {
-  /// Enqueue a transform to be computed asynchronously after `self` and `transform` become determined.
-  /// - parameter qos: the QOS class at which to execute the transform; defaults to the QOS class of this Deferred's queue.
-  /// - parameter transform: the transform to be performed, wrapped in a `Deferred`
-  /// - returns: a `Deferred` reference representing the return value of the transform
-
-  public func apply<Other>(qos: DispatchQoS? = nil, transform: Deferred<(Value) -> Result<Other>>) -> Deferred<Other>
-  {
-    return Applicator<Other>(qos: qos, source: self, transform: transform)
-  }
-
   /// Enqueue a transform to be computed asynchronously after `self` and `transform` become determined.
   /// - parameter qos: the QOS class at which to execute the transform; defaults to the QOS class of this Deferred's queue.
   /// - parameter transform: the transform to be performed, wrapped in a `Deferred`

--- a/Source/deferred/deferred-extras.swift
+++ b/Source/deferred/deferred-extras.swift
@@ -23,7 +23,7 @@ extension Deferred
 
   public func onValue(qos: DispatchQoS? = nil, task: @escaping (Value) -> Void)
   {
-    notify(qos: qos) { if case let .value(v) = $0 { task(v) } }
+    notify(qos: qos) { if let v = $0.value { task(v) } }
   }
 
   // MARK: onError: execute a task when (and only when) a computation fails
@@ -35,7 +35,7 @@ extension Deferred
 
   public func onError(qos: DispatchQoS? = nil, task: @escaping (Error) -> Void)
   {
-    notify(qos: qos) { if case let .error(e) = $0 { task(e) } }
+    notify(qos: qos) { if let e = $0.error { task(e) } }
   }
 }
 

--- a/Source/deferred/deferred.swift
+++ b/Source/deferred/deferred.swift
@@ -312,27 +312,32 @@ open class Deferred<Value>
     return resulto!
   }
 
-  /// Get this `Deferred` value, blocking if necessary until it becomes determined.
-  /// If the `Deferred` is determined by a `Result` in the `.error` state, return nil.
+  /// Get this `Deferred`'s value, blocking if necessary until it becomes determined.
+  /// If the `Deferred` is determined with an `Error`, throw it.
   /// In either case, this property will block until `Deferred` is determined.
   ///
   /// - returns: this `Deferred`'s determined value, or `nil`
 
-  public var value: Value? {
-    if case let .value(v) = result { return v }
-    return nil
+  public func await() throws -> Value
+  {
+    return try result.getValue()
   }
 
-  /// Get this `Deferred` value, blocking if necessary until it becomes determined.
-  /// If the `Deferred` is determined by a `Result` in the `.error` state, return nil.
+  /// Get this `Deferred`'s value, blocking if necessary until it becomes determined.
+  /// If the `Deferred` is determined with an `Error`, return nil.
   /// In either case, this property will block until `Deferred` is determined.
   ///
   /// - returns: this `Deferred`'s determined value, or `nil`
 
-  public var error: Error? {
-    if case let .error(e) = result { return e }
-    return nil
-  }
+  public var value: Value? { return result.value }
+
+  /// Get this `Deferred`'s error, blocking if necessary until it becomes determined.
+  /// If the `Deferred` is determined with a `Value`, return nil.
+  /// In either case, this property will block until `Deferred` is determined.
+  ///
+  /// - returns: this `Deferred`'s determined value, or `nil`
+
+  public var error: Error? { return result.error }
 
   /// Get the quality-of-service class of this `Deferred`'s queue
   /// - returns: the quality-of-service class of this `Deferred`'s queue

--- a/Source/deferred/deferred.swift
+++ b/Source/deferred/deferred.swift
@@ -35,6 +35,7 @@ extension UnsafeMutableRawPointer
 open class Deferred<Value>
 {
   fileprivate let queue: DispatchQueue
+  private var source: AnyObject?
 
   private var resulto: Result<Value>?
   private var waiters = CAtomicsMutablePointer()
@@ -50,13 +51,22 @@ open class Deferred<Value>
 
   // MARK: designated initializers
 
-  internal init(queue: DispatchQueue)
+  fileprivate init<Other>(queue: DispatchQueue? = nil, source: Deferred<Other>)
   {
+    self.queue = queue ?? source.queue
+    self.source = source
     resulto = nil
     CAtomicsMutablePointerInit(nil, &waiters)
     CAtomicsInt32Init(0, &stateid)
+  }
 
+  internal init(queue: DispatchQueue)
+  {
     self.queue = queue
+    source = nil
+    resulto = nil
+    CAtomicsMutablePointerInit(nil, &waiters)
+    CAtomicsInt32Init(0, &stateid)
   }
 
   /// Initialize to an already determined state
@@ -66,11 +76,11 @@ open class Deferred<Value>
 
   public init(queue: DispatchQueue, result: Result<Value>)
   {
+    self.queue = queue
+    source = nil
     resulto = result
     CAtomicsMutablePointerInit(.determined, &waiters)
     CAtomicsInt32Init(2, &stateid)
-
-    self.queue = queue
   }
 
   // MARK: initialize with a closure
@@ -92,11 +102,13 @@ open class Deferred<Value>
   /// - parameter qos:   the Quality-of-Service class at which the computation should be performed; defaults to the QOS class of `queue`
   /// - parameter task:  the computation to be performed
 
-  public convenience init(queue: DispatchQueue, qos: DispatchQoS? = nil, task: @escaping () throws -> Value)
+  public init(queue: DispatchQueue, qos: DispatchQoS? = nil, task: @escaping () throws -> Value)
   {
-    self.init(queue: queue)
-
-    CAtomicsInt32Store(1, &stateid, .relaxed)
+    self.queue = queue
+    source = nil
+    resulto = nil
+    CAtomicsMutablePointerInit(nil, &waiters)
+    CAtomicsInt32Init(1, &stateid)
 
     queue.async(qos: qos) {
       let result = Result { try task() }
@@ -201,10 +213,11 @@ open class Deferred<Value>
     }
 
     resulto = result
+    source = nil
 
     let waitQueue = CAtomicsMutablePointerSwap(.determined, &waiters, .acqrel)?.assumingMemoryBound(to: Waiter<Value>.self)
     // precondition(waitQueue != .determined)
-    notifyWaiters(queue, waitQueue, result)
+    notifyWaiters(queue, waitQueue, self)
 
     // precondition(waiters.load() == .determined, "waiters.pointer has incorrect value \(String(describing: waiters.load()))")
 
@@ -214,18 +227,19 @@ open class Deferred<Value>
 
   // MARK: public interface
 
-  /// Enqueue a closure to be performed asynchronously as a notification after this `Deferred` becomes determined.
+  /// Enqueue a closure to be performed asynchronously after this `Deferred` becomes determined.
   /// This operation is lock-free and thread-safe.
   /// Multiple threads can call this method at once; they will succeed in turn.
   /// If one or more thread enters a race to enqueue with `determine()`, as soon as `determine()` succeeds
   /// all current and subsequent attempts to enqueue will result in immediate dispatch of the task.
+  /// Note that the enqueued closure will does not modify `task`, and will not extend the lifetime of `self`.
   ///
   /// - parameter qos:  the Quality-of-Service class at which this notification should execute; defaults to the QOS class of this `Deferred`'s queue.
-  /// - parameter task: the closure to be executed as a notification
+  /// - parameter task: a closure to be executed after `self` becomes determined.
 
-  open func notify(qos: DispatchQoS? = nil, task: @escaping (Result<Value>) -> Void)
+  open func enqueue(qos: DispatchQoS? = nil, task: @escaping (Deferred) -> Void)
   {
-    var waitQueue = CAtomicsMutablePointerLoad(&waiters, .acquire)
+    var waitQueue = CAtomicsMutablePointerLoad(&waiters, .relaxed)
     if waitQueue != .determined
     {
       let waiter = UnsafeMutablePointer<Waiter<Value>>.allocate(capacity: 1)
@@ -233,7 +247,7 @@ open class Deferred<Value>
 
       repeat {
         waiter.pointee.next = waitQueue?.assumingMemoryBound(to: Waiter<Value>.self)
-        if CAtomicsMutablePointerCAS(&waitQueue, UnsafeMutableRawPointer(waiter), &waiters, .weak, .acqrel, .acquire)
+        if CAtomicsMutablePointerCAS(&waitQueue, UnsafeMutableRawPointer(waiter), &waiters, .weak, .release, .relaxed)
         { // waiter is now enqueued; it will be deallocated at a later time by WaitQueue.notifyAll()
           return
         }
@@ -245,9 +259,18 @@ open class Deferred<Value>
     }
 
     // this Deferred is determined
-    let result = resulto!
+    queue.async(qos: qos, execute: { task(self) })
+  }
 
-    queue.async(qos: qos, execute: { task(result) })
+  /// Enqueue a notification to be performed asynchronously after this `Deferred` becomes determined.
+  /// The enqueued closure will extend the lifetime of `self` until `task` completes.
+  ///
+  /// - parameter qos:  the Quality-of-Service class at which this notification should execute; defaults to the QOS class of this `Deferred`'s queue.
+  /// - parameter task: a closure to be executed as a notification
+
+  public func notify(qos: DispatchQoS? = nil, task: @escaping (Deferred) -> Void)
+  {
+    enqueue(qos: qos, task: { deferred in withExtendedLifetime(self) { task(deferred) } })
   }
 
   /// Query the current state of this `Deferred`
@@ -304,7 +327,7 @@ open class Deferred<Value>
     if CAtomicsMutablePointerLoad(&waiters, .acquire) != .determined
     {
       let s = DispatchSemaphore(value: 0)
-      self.notify(qos: DispatchQoS.current) { _ in s.signal() }
+      self.enqueue(qos: DispatchQoS.current) { _ in s.signal() }
       s.wait()
     }
 
@@ -350,8 +373,8 @@ open class Deferred<Value>
       return Deferred(queue: queue, result: resulto!)
     }
 
-    let deferred = Deferred(queue: queue)
-    self.notify(qos: queue.qos, task: { deferred.determine($0) })
+    let deferred = Deferred(queue: queue, source: self)
+    self.enqueue(qos: queue.qos, task: { deferred.determine($0.result) })
     return deferred
   }
 
@@ -382,14 +405,15 @@ internal final class Mapped<Value>: Deferred<Value>
 
   init<U>(qos: DispatchQoS?, source: Deferred<U>, transform: @escaping (U) throws -> Value)
   {
-    super.init(queue: source.queue)
+    super.init(source: source)
 
-    source.notify(qos: qos) {
-      result in
-      if self.isDetermined { return }
-      self.beginExecution()
-      let transformed = result.map(transform)
-      self.determine(transformed) // an error here means this `Deferred` has been canceled.
+    source.enqueue(qos: qos) {
+      [weak self] deferred in
+      guard let this = self else { return }
+      if this.isDetermined { return }
+      this.beginExecution()
+      let transformed = deferred.result.map(transform)
+      this.determine(transformed) // an error here means this `Deferred` has been canceled.
     }
   }
 
@@ -406,11 +430,12 @@ internal final class Mapped<Value>: Deferred<Value>
     super.init(queue: source.queue)
 
     source.notify(qos: qos) {
-      result in
-      if self.isDetermined { return }
-      self.beginExecution()
-      let transformed = result.flatMap(transform)
-      self.determine(transformed) // an error here means this `Deferred` has been canceled.
+      [weak self] deferred in
+      guard let this = self else { return }
+      if this.isDetermined { return }
+      this.beginExecution()
+      let transformed = deferred.result.flatMap(transform)
+      this.determine(transformed) // an error here means this `Deferred` has been canceled.
     }
   }
 }
@@ -427,22 +452,24 @@ internal final class Bind<Value>: Deferred<Value>
 
   init<U>(qos: DispatchQoS?, source: Deferred<U>, transform: @escaping (U) -> Deferred<Value>)
   {
-    super.init(queue: source.queue)
+    super.init(source: source)
 
-    source.notify(qos: qos) {
-      result in
-      if self.isDetermined { return }
-      self.beginExecution()
-      switch result
+    source.enqueue(qos: qos) {
+      [weak self] deferred in
+      guard let this = self else { return }
+      if this.isDetermined { return }
+      this.beginExecution()
+      switch deferred.result
       {
       case .value(let value):
         transform(value).notify(qos: qos) {
-          transformed in
-          self.determine(transformed) // an error here means this `Deferred` has been canceled.
+          [weak self] transformed in
+          guard let this = self else { return }
+          this.determine(transformed.result) // an error here means this `Deferred` has been canceled.
         }
 
       case .error(let error):
-        self.determine(Result.error(error)) // an error here means this `Deferred` has been canceled.
+        this.determine(Result.error(error)) // an error here means this `Deferred` has been canceled.
       }
     }
   }
@@ -457,21 +484,24 @@ internal final class Bind<Value>: Deferred<Value>
 
   init(qos: DispatchQoS?, source: Deferred<Value>, transform: @escaping (Error) -> Deferred<Value>)
   {
-    super.init(queue: source.queue)
+    super.init(source: source)
 
-    source.notify(qos: qos) {
-      result in
-      if self.isDetermined { return }
-      self.beginExecution()
+    source.enqueue(qos: qos) {
+      [weak self] deferred in
+      guard let this = self else { return }
+      if this.isDetermined { return }
+      this.beginExecution()
+      let result = deferred.result
       switch result
       {
       case .value:
-        self.determine(result)
+        this.determine(result)
 
       case .error(let error):
         transform(error).notify(qos: qos) {
-          transformed in
-          self.determine(transformed)
+          [weak self] transformed in
+          guard let this = self else { return }
+          this.determine(transformed.result)
         }
       }
     }
@@ -495,22 +525,24 @@ internal final class Applicator<Value>: Deferred<Value>
     super.init(queue: source.queue)
 
     source.notify(qos: qos) {
-      result in
-      if self.isDetermined { return }
+      [weak self] deferred in
+      guard let this = self else { return }
+      if this.isDetermined { return }
+      let result = deferred.result
       switch result
       {
       case .value:
-        transform.notifying(on: self.queue).notify(qos: qos) {
-          transform in
-          if self.isDetermined { return }
-          self.beginExecution()
-          let transformed = result.apply(transform)
-          self.determine(transformed) // an error here means this `Deferred` has been canceled.
+        transform.notifying(on: this.queue).notify(qos: qos) {
+          [weak self] transform in
+          guard let this = self else { return }
+          if this.isDetermined { return }
+          this.beginExecution()
+          let transformed = result.apply(transform.result)
+          this.determine(transformed) // an error here means this `Deferred` has been canceled.
         }
 
       case .error(let error):
-        self.beginExecution()
-        self.determine(Result.error(error)) // an error here means this `Deferred` has been canceled.
+        this.determine(Result.error(error)) // an error here means this `Deferred` has been canceled.
       }
     }
   }
@@ -525,25 +557,27 @@ internal final class Applicator<Value>: Deferred<Value>
 
   init<U>(qos: DispatchQoS?, source: Deferred<U>, transform: Deferred<(U) throws -> Value>)
   {
-    super.init(queue: source.queue)
+    super.init(source: source)
 
-    source.notify(qos: qos) {
-      result in
-      if self.isDetermined { return }
+    source.enqueue(qos: qos) {
+      [weak self] deferred in
+      guard let this = self else { return }
+      if this.isDetermined { return }
+      let result = deferred.result
       switch result
       {
       case .value:
-        transform.notifying(on: self.queue).notify(qos: qos) {
-          transform in
-          if self.isDetermined { return }
-          self.beginExecution()
-          let transformed = result.apply(transform)
-          self.determine(transformed) // an error here means this `Deferred` has been canceled.
+        transform.notifying(on: this.queue).notify(qos: qos) {
+          [weak self] transform in
+          guard let this = self else { return }
+          if this.isDetermined { return }
+          this.beginExecution()
+          let transformed = result.apply(transform.result)
+          this.determine(transformed) // an error here means this `Deferred` has been canceled.
         }
 
       case .error(let error):
-        self.beginExecution()
-        self.determine(Result.error(error)) // an error here means this `Deferred` has been canceled.
+        this.determine(Result.error(error)) // an error here means this `Deferred` has been canceled.
       }
     }
   }
@@ -563,28 +597,31 @@ internal final class Delayed<Value>: Deferred<Value>
 
   init(source: Deferred<Value>, until time: DispatchTime)
   {
-    super.init(queue: source.queue)
+    super.init(source: source)
 
-    source.notify {
-      result in
-      if self.isDetermined { return }
+    source.enqueue {
+      [weak self] deferred in
+      guard let this = self else { return }
+      if this.isDetermined { return }
+
+      let result = deferred.result
 
       if case .error = result
       {
-        self.determine(result)
+        this.determine(result)
         return
       }
 
-      self.beginExecution()
+      this.beginExecution()
       if time == .distantFuture { return }
       // enqueue block only if can get executed
       if time > .now()
       {
-        self.queue.asyncAfter(deadline: time) { self.determine(result) }
+        this.queue.asyncAfter(deadline: time) { this.determine(result) }
       }
       else
       {
-        self.determine(result)
+        this.determine(result)
       }
     }
   }

--- a/Source/deferred/nsurlsession.swift
+++ b/Source/deferred/nsurlsession.swift
@@ -60,11 +60,11 @@ public class DeferredURLSessionTask<Value>: TBD<Value>
     }
   }
 
-  public override func notify(qos: DispatchQoS? = nil, task: @escaping (Result<Value>) -> Void)
+  public override func enqueue(qos: DispatchQoS? = nil, task: @escaping (Deferred<Value>) -> Void)
   {
     self.task?.resume()
     self.beginExecution()
-    super.notify(qos: qos, task: task)
+    super.enqueue(qos: qos, task: task)
   }
 }
 

--- a/Source/deferred/result.swift
+++ b/Source/deferred/result.swift
@@ -13,12 +13,12 @@ import class Foundation.NSError
 /// The error case does not encode type beyond the Error protocol.
 /// This way there is no need to ever map between error types, which mostly cannot make sense.
 
-public enum Result<Value>: CustomStringConvertible
+enum Result<Value>: CustomStringConvertible
 {
   case value(Value)
   case error(Error)
 
-  public init(task: () throws -> Value)
+  init(task: () throws -> Value)
   {
     do {
       let value = try task()
@@ -29,7 +29,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public init(_ optional: Value?, or error: Error)
+  init(_ optional: Value?, or error: Error)
   {
     switch optional
     {
@@ -38,7 +38,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public var value: Value? {
+  var value: Value? {
     switch self
     {
     case .value(let value): return value
@@ -46,7 +46,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public var isValue: Bool {
+  var isValue: Bool {
     switch self
     {
     case .value: return true
@@ -54,7 +54,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public var error: Error? {
+  var error: Error? {
     switch self
     {
     case .value:            return nil
@@ -62,7 +62,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public var isError: Bool {
+  var isError: Bool {
     switch self
     {
     case .value: return false
@@ -70,7 +70,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public func getValue() throws -> Value
+  func getValue() throws -> Value
   {
     switch self
     {
@@ -80,7 +80,7 @@ public enum Result<Value>: CustomStringConvertible
   }
 
 
-  public var description: String {
+  var description: String {
     switch self
     {
     case .value(let value): return String(describing: value)
@@ -89,7 +89,7 @@ public enum Result<Value>: CustomStringConvertible
   }
 
 
-  public func map<Other>(_ transform: (Value) throws -> Other) -> Result<Other>
+  func map<Other>(_ transform: (Value) throws -> Other) -> Result<Other>
   {
     switch self
     {
@@ -98,7 +98,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public func flatMap<Other>(_ transform: (Value) -> Result<Other>) -> Result<Other>
+  func flatMap<Other>(_ transform: (Value) -> Result<Other>) -> Result<Other>
   {
     switch self
     {
@@ -107,7 +107,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public func apply<Other>(_ transform: Result<(Value) throws -> Other>) -> Result<Other>
+  func apply<Other>(_ transform: Result<(Value) throws -> Other>) -> Result<Other>
   {
     switch self
     {
@@ -122,7 +122,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public func apply<Other>(_ transform: Result<(Value) -> Result<Other>>) -> Result<Other>
+  func apply<Other>(_ transform: Result<(Value) -> Result<Other>>) -> Result<Other>
   {
     switch self
     {
@@ -137,7 +137,7 @@ public enum Result<Value>: CustomStringConvertible
     }
   }
 
-  public func recover(_ transform: (Error) -> Result<Value>) -> Result<Value>
+  func recover(_ transform: (Error) -> Result<Value>) -> Result<Value>
   {
     switch self
     {
@@ -147,7 +147,7 @@ public enum Result<Value>: CustomStringConvertible
   }
 }
 
-public func ?? <Value> (possible: Result<Value>, alternate: @autoclosure () -> Value) -> Value
+func ?? <Value> (possible: Result<Value>, alternate: @autoclosure () -> Value) -> Value
 {
   switch possible
   {
@@ -156,7 +156,7 @@ public func ?? <Value> (possible: Result<Value>, alternate: @autoclosure () -> V
   }
 }
 
-public func == <Value: Equatable> (lhr: Result<Value>, rhr: Result<Value>) -> Bool
+func == <Value: Equatable> (lhr: Result<Value>, rhr: Result<Value>) -> Bool
 {
   switch (lhr, rhr)
   {
@@ -171,12 +171,12 @@ public func == <Value: Equatable> (lhr: Result<Value>, rhr: Result<Value>) -> Bo
   }
 }
 
-public func != <Value: Equatable> (lhr: Result<Value>, rhr: Result<Value>) -> Bool
+func != <Value: Equatable> (lhr: Result<Value>, rhr: Result<Value>) -> Bool
 {
   return !(lhr == rhr)
 }
 
-public func == <C: Collection, Value: Equatable> (lha: C, rha: C) -> Bool
+func == <C: Collection, Value: Equatable> (lha: C, rha: C) -> Bool
   where C.Iterator.Element == Result<Value>
 {
   guard lha.count == rha.count else { return false }
@@ -189,7 +189,7 @@ public func == <C: Collection, Value: Equatable> (lha: C, rha: C) -> Bool
   return true
 }
 
-public func != <C: Collection, Value: Equatable> (lha: C, rha: C) -> Bool
+func != <C: Collection, Value: Equatable> (lha: C, rha: C) -> Bool
   where C.Iterator.Element == Result<Value>
 {
   return !(lha == rha)

--- a/Source/deferred/waiter.swift
+++ b/Source/deferred/waiter.swift
@@ -11,29 +11,29 @@ import Dispatch
 struct Waiter<T>
 {
   private let qos: DispatchQoS?
-  private let handler: (Result<T>) -> Void
+  private let handler: (Deferred<T>) -> Void
   var next: UnsafeMutablePointer<Waiter<T>>? = nil
 
-  init(_ qos: DispatchQoS? = nil, _ handler: @escaping (Result<T>) -> Void)
+  init(_ qos: DispatchQoS? = nil, _ handler: @escaping (Deferred<T>) -> Void)
   {
     self.qos = qos
     self.handler = handler
   }
 
-  fileprivate func notify(_ queue: DispatchQueue, _ result: Result<T>)
+  fileprivate func notify(_ queue: DispatchQueue, _ result: Deferred<T>)
   {
     queue.async(qos: qos) { [ handler = self.handler ] in handler(result) }
   }
 }
 
-func notifyWaiters<T>(_ queue: DispatchQueue, _ tail: UnsafeMutablePointer<Waiter<T>>?, _ result: Result<T>)
+func notifyWaiters<T>(_ queue: DispatchQueue, _ tail: UnsafeMutablePointer<Waiter<T>>?, _ deferred: Deferred<T>)
 {
   var head = reverseList(tail)
   while let current = head
   {
     head = current.pointee.next
 
-    current.pointee.notify(queue, result)
+    current.pointee.notify(queue, deferred)
 
     current.deinitialize(count: 1)
     current.deallocate(capacity: 1)

--- a/Tests/deferredTests/DeferredCombinationTests.swift
+++ b/Tests/deferredTests/DeferredCombinationTests.swift
@@ -191,20 +191,17 @@ class DeferredCombinationTests: XCTestCase
 
     deferreds.forEach {
       d in
-      switch d.result
-      {
-      case .value(let value):
+      do {
+        let value = try d.await()
         XCTAssert(value == lucky)
-      case .error(let error as DeferredError):
-        XCTAssert(error == DeferredError.canceled(""))
-      case .error(let error):
-        XCTFail("Wrong error: \(error)")
       }
+      catch DeferredError.canceled(let s) { XCTAssert(s == "") }
+      catch { XCTFail("Wrong error: \(error)") }
     }
 
     let never = firstValue(EmptyIterator<Deferred<Any>>())
     do {
-      _ = try never.result.getValue()
+      _ = try never.await()
       XCTFail()
     }
     catch DeferredError.canceled(let s) { XCTAssert(s != "") }
@@ -276,13 +273,11 @@ class DeferredCombinationTimedTests: XCTestCase
       let inputs = (1...iterations).map { Deferred(value: $0) }
       self.startMeasuring()
       let c = reduce(inputs, initial: 0, combine: +)
-      switch c.result
-      {
-      case .value(let v):
+      do {
+        let v = try c.await()
         XCTAssert(v == (iterations*(iterations+1)/2))
-      default:
-        XCTFail()
       }
+      catch { XCTFail() }
       self.stopMeasuring()
     }
   }
@@ -301,13 +296,11 @@ class DeferredCombinationTimedTests: XCTestCase
           u in deferred.map { t in u+t }
         }
       }
-      switch c.result
-      {
-      case .value(let v):
+      do {
+        let v = try c.await()
         XCTAssert(v == (iterations*(iterations+1)/2))
-      default:
-        XCTFail()
       }
+      catch { XCTFail() }
       self.stopMeasuring()
     }
   }
@@ -320,13 +313,11 @@ class DeferredCombinationTimedTests: XCTestCase
       let inputs = (1...iterations).map { Deferred(value: $0) }
       self.startMeasuring()
       let c = combine(inputs)
-      switch c.result
-      {
-      case .value(let v):
+      do {
+        let v = try c.await()
         XCTAssert(v.count == iterations)
-      default:
-        XCTFail()
       }
+      catch { XCTFail() }
       self.stopMeasuring()
     }
   }

--- a/Tests/deferredTests/DeferredCombinationTests.swift
+++ b/Tests/deferredTests/DeferredCombinationTests.swift
@@ -38,9 +38,9 @@ class DeferredCombinationTests: XCTestCase
     }
     c.notify { _ in e.fulfill() }
 
-    XCTAssert(c.result.isValue == false)
-    XCTAssert(c.result.isError)
-    if let error = c.result.error as? TestError
+    XCTAssert(c.value == nil)
+    XCTAssert(c.error != nil)
+    if let error = c.error as? TestError
     {
       XCTAssert(error.error >= 9)
     }

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -28,6 +28,7 @@ class DeferredTests: XCTestCase
     ("testValue", testValue),
     ("testValueBlocks", testValueBlocks),
     ("testValueUnblocks", testValueUnblocks),
+    ("testAwait", testAwait),
     ("testOptional", testOptional),
     ("testNotify1", testNotify1),
     ("testNotify2", testNotify2),
@@ -222,6 +223,23 @@ class DeferredTests: XCTestCase
     }
 
     waitForExpectations(timeout: 2.0)
+  }
+
+  func testAwait()
+  {
+    let e = TestError(1)
+    let d1 = Deferred(value: 1.0)
+    let d2 = d1.map(transform: { _  throws -> Double in throw e})
+    var double = Optional<Double>.none
+    do {
+      double = try d1.await()
+      double = try d2.await()
+      XCTFail()
+    } catch let error as TestError {
+      XCTAssert(error == e)
+    } catch { XCTFail() }
+
+    XCTAssert(double == 1.0)
   }
 
   func testNotify1()

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -250,7 +250,7 @@ class DeferredTests: XCTestCase
     let e1 = expectation(description: "Pre-set Deferred")
     let d1 = Deferred(value: value)
     d1.notify {
-      XCTAssert( $0 == Result.value(value) )
+      XCTAssert( $0.value == value )
       e1.fulfill()
     }
     waitForExpectations(timeout: 1.0)
@@ -265,7 +265,7 @@ class DeferredTests: XCTestCase
     let q3 = DispatchQueue(label: "Test", qos: .background)
     let d3 = d2.notifying(on: q3)
     d3.notify(qos: .utility) {
-      XCTAssert( $0 == Result.value(value) )
+      XCTAssert( $0.value == value )
       e2.fulfill()
     }
     waitForExpectations(timeout: 1.0)
@@ -280,8 +280,8 @@ class DeferredTests: XCTestCase
       return 42
     }
     d3.notify {
-      result in
-      guard case let .error(e) = result,
+      deferred in
+      guard let e = deferred.error,
             let deferredErr = e as? DeferredError,
             case .canceled = deferredErr
       else
@@ -488,9 +488,9 @@ class DeferredTests: XCTestCase
     var v1 = 0
     var v2 = 0
     result.notify {
-      result in
+      deferred in
       print("\(v1), \(v2), \(result)")
-      XCTAssert(result == Result.value(Double(v1*v2)))
+      XCTAssert(deferred.value == Double(v1*v2))
       expect.fulfill()
     }
 

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -26,7 +26,6 @@ class DeferredTests: XCTestCase
     ("testDeferredError", testDeferredError),
     ("testDelay", testDelay),
     ("testValue", testValue),
-    ("testPeek", testPeek),
     ("testValueBlocks", testValueBlocks),
     ("testValueUnblocks", testValueUnblocks),
     ("testOptional", testOptional),
@@ -164,23 +163,6 @@ class DeferredTests: XCTestCase
     let d = Deferred(value: value)
     XCTAssert(d.value == value)
     XCTAssert(d.isDetermined)
-  }
-
-  func testPeek()
-  {
-    let value = 1
-    let d1 = Deferred(value: value)
-    XCTAssert(d1.peek()! == Result.value(value))
-
-    let d2 = d1.delay(.microseconds(10_000))
-    XCTAssert(d2.peek() == nil)
-    XCTAssert(d2.isDetermined == false)
-
-    _ = d2.value // Wait for delay
-
-    XCTAssert(d2.peek() != nil)
-    XCTAssert(d2.peek()! == Result.value(value))
-    XCTAssert(d2.isDetermined)
   }
 
   func testValueBlocks()

--- a/Tests/deferredTests/DeletionTests.swift
+++ b/Tests/deferredTests/DeletionTests.swift
@@ -18,6 +18,8 @@ class DeletionTests: XCTestCase
     ("testDeallocDeferred1", testDeallocDeferred1),
     ("testDeallocDeferred2", testDeallocDeferred2),
     ("testDeallocDeferred3", testDeallocDeferred3),
+    ("testDeallocDeferred4", testDeallocDeferred4),
+    ("testDelayedDeallocDeferred", testDelayedDeallocDeferred),
     ("testDeallocTBD1", testDeallocTBD1),
     ("testDeallocTBD2", testDeallocTBD2),
     ("testDeallocTBD3", testDeallocTBD3),
@@ -64,6 +66,32 @@ class DeletionTests: XCTestCase
     }
 
     waitForExpectations(timeout: 0.1)
+  }
+
+  func testDeallocDeferred4()
+  {
+    let mapped: Deferred<Void> = {
+      let deferred = Dealloc(expectation: expectation(description: "will dealloc deferred 4"))
+      return deferred.map { _ in XCTFail("Unexpected notification") }
+    }()
+    mapped.cancel()
+
+    waitForExpectations(timeout: 0.1)
+  }
+
+  func testDelayedDeallocDeferred()
+  {
+    let witness: Deferred<Void>
+    let e = expectation(description: "deallocation delay")
+    do {
+      let queue = DispatchQueue(label: "\(#function)")
+      let delayed = Deferred(queue: queue, value: ()).delay(.milliseconds(50))
+      _ = delayed.map { XCTFail("a value no one waits for should not be computed") }
+      witness = delayed.map { e.fulfill() }
+    }
+
+    waitForExpectations(timeout: 0.5)
+    _ = witness.value
   }
 
   class DeallocTBD: TBD<Void>

--- a/Tests/deferredTests/TBDTests.swift
+++ b/Tests/deferredTests/TBDTests.swift
@@ -121,7 +121,7 @@ class TBDTests: XCTestCase
     tbd.determine(value)
 
     tbd.notify {
-      XCTAssert( $0 == Result.value(value) )
+      XCTAssert( $0.value == value )
       e1.fulfill()
     }
     waitForExpectations(timeout: 1.0)
@@ -134,7 +134,7 @@ class TBDTests: XCTestCase
 
     var value = nzRandom()
     tbd.notify {
-      XCTAssert( $0 == Result.value(value) )
+      XCTAssert( $0.value == value )
       e2.fulfill()
     }
 
@@ -151,9 +151,9 @@ class TBDTests: XCTestCase
     let e3 = expectation(description: "TBD never determined")
     let d3 = TBD<Int>()
     d3.notify {
-      result in
+      deferred in
       do {
-        _ = try result.getValue()
+        _ = try deferred.result.getValue()
         XCTFail()
       }
       catch DeferredError.canceled {}
@@ -232,8 +232,8 @@ class TBDTests: XCTestCase
     let d = Deferred.inParallel(count: count, queue: q) { $0 }
     let c = combine(d)
     c.notify {
-      r in
-      switch r
+      deferred in
+      switch deferred.result
       {
       case .value(let value):
         XCTAssert(value.count == count)

--- a/Tests/deferredTests/TBDTimingTests.swift
+++ b/Tests/deferredTests/TBDTimingTests.swift
@@ -41,16 +41,13 @@ class TBDTimingTests: XCTestCase
 
       first.determine( (0, ref, ref) )
 
-      switch dt.result
-      {
-      case let .value(iterations, tic, toc):
+      do {
+        let (iterations, tic, toc) = try dt.await()
         let interval = toc.timeIntervalSince(tic)
         // print("\(round(Double(interval*1e9)/Double(iterations))/1000) µs per message")
         _ = interval/Double(iterations)
-        break
-
-      default: XCTFail()
       }
+      catch { XCTFail() }
     }
   }
 
@@ -68,15 +65,12 @@ class TBDTimingTests: XCTestCase
       let dt = start.map { start in Date().timeIntervalSince(start) }
       start.determine(Date())
 
-      switch dt.result
-      {
-      case .value(let interval):
+      do {
+        let interval = try dt.await()
         // print("\(round(Double(interval*1e9)/Double(iterations))/1000) µs per notification")
         _ = interval
-        break
-
-      default: XCTFail()
       }
+      catch { XCTFail() }
     }
   }
 }

--- a/Tests/deferredTests/TestError.swift
+++ b/Tests/deferredTests/TestError.swift
@@ -6,21 +6,10 @@
 //  Copyright © 2015 Guillaume Lessard. All rights reserved.
 //
 
-import enum deferred.Result
-
 struct TestError: Error, Equatable
 {
   let error: Int
   init(_ e: Int = 0) { error = e }
-
-  func matches<T>(_ result: Result<T>) -> Bool
-  {
-    if let e = result.error as? TestError
-    {
-      return self == e
-    }
-    return false
-  }
 }
 
 func == (l: TestError, r: TestError) -> Bool


### PR DESCRIPTION
This enables an object ownership graph bugfix.

Instances initialized through chaining operations now hold a reference to their source `Deferred`; the closures enqueued through `map`, `flatMap` and similar operations no longer hold strong references behind the scenes, reducing the exposure to memory leaks.