### PR TITLE
use automatic generation of Linux test list supplied by swiftpm

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,12 +1,8 @@
 import XCTest
-@testable import deferredTests
 
-XCTMain([
-  testCase(DeferredTests.allTests),
-  testCase(DeferredCombinationTests.allTests),
-  testCase(DeferredCombinationTimedTests.allTests),
-  testCase(DeletionTests.allTests),
-  testCase(DispatchUtilitiesTests.allTests),
-  testCase(TBDTests.allTests),
-  testCase(TBDTimingTests.allTests),
-])
+import deferredTests
+
+var tests = [XCTestCaseEntry]()
+tests += deferredTests.__allTests()
+
+XCTMain(tests)

--- a/Tests/deferredTests/DeferredCombinationTests.swift
+++ b/Tests/deferredTests/DeferredCombinationTests.swift
@@ -13,20 +13,6 @@ import deferred
 
 class DeferredCombinationTests: XCTestCase
 {
-  static var allTests = [
-    ("testReduce", testReduce),
-    ("testReduceCancel", testReduceCancel),
-    ("testCombineArray1", testCombineArray1),
-    ("testCombineArray2", testCombineArray2),
-    ("testCombine2", testCombine2),
-    ("testCombine3", testCombine3),
-    ("testCombine4", testCombine4),
-    ("testFirstValueCollection", testFirstValueCollection),
-    ("testFirstValueSequence", testFirstValueSequence),
-    ("testFirstDeterminedCollection", testFirstDeterminedCollection),
-    ("testFirstDeterminedSequence", testFirstDeterminedSequence),
-  ]
-
   func testReduce()
   {
     let count = 9
@@ -287,14 +273,6 @@ class DeferredCombinationTests: XCTestCase
 
 class DeferredCombinationTimedTests: XCTestCase
 {
-  static var allTests: [(String, (DeferredCombinationTimedTests) -> () throws -> Void)] {
-    return [
-      ("testPerformanceReduce", testPerformanceReduce),
-      ("testPerformanceCombine", testPerformanceCombine),
-      ("testPerformanceABAProneReduce", testPerformanceABAProneReduce),
-    ]
-  }
-
   let loopTestCount = 5_000
 
 #if swift(>=4.0) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) || (swift(>=4.1) && os(Linux))

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -15,46 +15,6 @@ import deferred
 
 class DeferredTests: XCTestCase
 {
-  static var allTests = [
-    ("testExample", testExample),
-    ("testExample2", testExample2),
-    ("testExample3", testExample3),
-    ("testDeferredError", testDeferredError),
-    ("testDelay", testDelay),
-    ("testValue", testValue),
-    ("testPeek", testPeek),
-    ("testValueBlocks", testValueBlocks),
-    ("testValueUnblocks", testValueUnblocks),
-    ("testState", testState),
-    ("testGet", testGet),
-    ("testOptional", testOptional),
-    ("testNotify1", testNotify1),
-    ("testNotify2", testNotify2),
-    ("testNotify3", testNotify3),
-    ("testNotify4", testNotify4),
-    ("testMap", testMap),
-    ("testRecover", testRecover),
-    ("testRetrying1", testRetrying1),
-    ("testRetrying2", testRetrying2),
-    ("testRetryTask", testRetryTask),
-    ("testFlatMap", testFlatMap),
-    ("testFlatten", testFlatten),
-    ("testApply", testApply),
-    ("testApply1", testApply1),
-    ("testApply2", testApply2),
-    ("testApply3", testApply3),
-    ("testQoS", testQoS),
-    ("testCancel", testCancel),
-    ("testCancelAndNotify", testCancelAndNotify),
-    ("testCancelMap", testCancelMap),
-    ("testCancelDelay", testCancelDelay),
-    ("testCancelBind", testCancelBind),
-    ("testCancelApply", testCancelApply),
-    ("testTimeout", testTimeout),
-    ("testValidate1", testValidate1),
-    ("testValidate2", testValidate2),
-  ].sorted(by: {$0.0 < $1.0})
-
   func testExample()
   {
     print("Starting")

--- a/Tests/deferredTests/DeletionTests.swift
+++ b/Tests/deferredTests/DeletionTests.swift
@@ -14,15 +14,6 @@ import deferred
 
 class DeletionTests: XCTestCase
 {
-  static var allTests = [
-    ("testDelayedDeallocDeferred", testDelayedDeallocDeferred),
-    ("testDeallocTBD1", testDeallocTBD1),
-    ("testDeallocTBD2", testDeallocTBD2),
-    ("testDeallocTBD3", testDeallocTBD3),
-    ("testDeallocTBD4", testDeallocTBD4),
-    ("testLongTaskCancellation", testLongTaskCancellation),
-  ]
-
   func testDelayedDeallocDeferred()
   {
     let witness: Deferred<Void>

--- a/Tests/deferredTests/DeterminedTests.swift
+++ b/Tests/deferredTests/DeterminedTests.swift
@@ -12,21 +12,9 @@ import XCTest
 
 class DeterminedTests: XCTestCase
 {
-#if swift (>=4.1)
-  static var allTests = [
-    ("testEquals1", testEquals1),
-    ("testEquals2", testEquals2),
-    ("testGetters", testGetters),
-  ].sorted(by: {$0.0 < $1.0})
-#else
-  static var allTests = [
-    ("testGetters", testGetters)
-  ]
-#endif
-
-#if swift (>=4.1)
   func testEquals1()
   {
+#if swift (>=4.1)
     let t1 = TBD<Int>()
     let t2 = TBD<Int>()
 
@@ -49,10 +37,12 @@ class DeterminedTests: XCTestCase
     t2.determine(nzRandom())
 
     waitForExpectations(timeout: 1.0)
+#endif
   }
 
   func testEquals2()
   {
+#if swift (>=4.1)
     let ev = nzRandom()
 
     let t1 = TBD<Int>()
@@ -77,8 +67,8 @@ class DeterminedTests: XCTestCase
     t1.determine(ev)
 
     waitForExpectations(timeout: 1.0)
-  }
 #endif
+  }
 
   func testGetters() throws
   {

--- a/Tests/deferredTests/DispatchUtilitiesTests.swift
+++ b/Tests/deferredTests/DispatchUtilitiesTests.swift
@@ -14,12 +14,6 @@ import Dispatch
 
 class DispatchUtilitiesTests: XCTestCase
 {
-  static var allTests = [
-    ("testQoSClass", testQoSClass),
-    ("testQoS", testQoS),
-    ("testCurrent", testCurrent),
-  ]
-
   func testQoSClass()
   {
     let classes: [DispatchQoS.QoSClass] = [.unspecified, .background, .utility, .default, .userInitiated, .userInteractive]

--- a/Tests/deferredTests/TBDTests.swift
+++ b/Tests/deferredTests/TBDTests.swift
@@ -15,21 +15,6 @@ import deferred
 
 class TBDTests: XCTestCase
 {
-  static var allTests = [
-    ("testDetermine1", testDetermine1),
-    ("testDetermine2", testDetermine2),
-    ("testCancel", testCancel),
-    ("testNotify1", testNotify1),
-    ("testNotify2", testNotify2),
-    ("testNotify3", testNotify3),
-    ("testNotify4", testNotify4),
-    ("testNeverDetermined", testNeverDetermined),
-    ("testParallel1", testParallel1),
-    ("testParallel2", testParallel2),
-    ("testParallel3", testParallel3),
-    ("testParallel4", testParallel4),
-  ]
-
   func testDetermine1()
   {
     let tbd = TBD<Int>()

--- a/Tests/deferredTests/TBDTimingTests.swift
+++ b/Tests/deferredTests/TBDTimingTests.swift
@@ -15,11 +15,6 @@ import deferred
 
 class TBDTimingTests: XCTestCase
 {
-  static var allTests = [
-    ("testPerformancePropagationTime", testPerformancePropagationTime),
-    ("testPerformanceNotificationTime", testPerformanceNotificationTime),
-  ]
-
   let propagationTestCount = 10_000
 
   func testPerformancePropagationTime()

--- a/Tests/deferredTests/XCTestManifests.swift
+++ b/Tests/deferredTests/XCTestManifests.swift
@@ -1,0 +1,133 @@
+import XCTest
+
+extension DeferredCombinationTests {
+    static let __allTests = [
+        ("testCombine2", testCombine2),
+        ("testCombine3", testCombine3),
+        ("testCombine4", testCombine4),
+        ("testCombineArray1", testCombineArray1),
+        ("testCombineArray2", testCombineArray2),
+        ("testFirstDeterminedCollection", testFirstDeterminedCollection),
+        ("testFirstDeterminedSequence", testFirstDeterminedSequence),
+        ("testFirstValueCollection", testFirstValueCollection),
+        ("testFirstValueSequence", testFirstValueSequence),
+        ("testReduce", testReduce),
+        ("testReduceCancel", testReduceCancel),
+    ]
+}
+
+extension DeferredCombinationTimedTests {
+    static let __allTests = [
+        ("testPerformanceABAProneReduce", testPerformanceABAProneReduce),
+        ("testPerformanceCombine", testPerformanceCombine),
+        ("testPerformanceReduce", testPerformanceReduce),
+    ]
+}
+
+extension DeferredTests {
+    static let __allTests = [
+        ("testApply", testApply),
+        ("testApply1", testApply1),
+        ("testApply2", testApply2),
+        ("testApply3", testApply3),
+        ("testCancel", testCancel),
+        ("testCancelAndNotify", testCancelAndNotify),
+        ("testCancelApply", testCancelApply),
+        ("testCancelBind", testCancelBind),
+        ("testCancelDelay", testCancelDelay),
+        ("testCancelMap", testCancelMap),
+        ("testDeferredError", testDeferredError),
+        ("testDelay", testDelay),
+        ("testExample", testExample),
+        ("testExample2", testExample2),
+        ("testExample3", testExample3),
+        ("testFlatMap", testFlatMap),
+        ("testFlatten", testFlatten),
+        ("testGet", testGet),
+        ("testMap", testMap),
+        ("testNotify1", testNotify1),
+        ("testNotify2", testNotify2),
+        ("testNotify3", testNotify3),
+        ("testNotify4", testNotify4),
+        ("testOptional", testOptional),
+        ("testPeek", testPeek),
+        ("testQoS", testQoS),
+        ("testRecover", testRecover),
+        ("testRetrying1", testRetrying1),
+        ("testRetrying2", testRetrying2),
+        ("testRetryTask", testRetryTask),
+        ("testState", testState),
+        ("testTimeout", testTimeout),
+        ("testValidate1", testValidate1),
+        ("testValidate2", testValidate2),
+        ("testValue", testValue),
+        ("testValueBlocks", testValueBlocks),
+        ("testValueUnblocks", testValueUnblocks),
+    ]
+}
+
+extension DeletionTests {
+    static let __allTests = [
+        ("testDeallocTBD1", testDeallocTBD1),
+        ("testDeallocTBD2", testDeallocTBD2),
+        ("testDeallocTBD3", testDeallocTBD3),
+        ("testDeallocTBD4", testDeallocTBD4),
+        ("testDelayedDeallocDeferred", testDelayedDeallocDeferred),
+        ("testLongTaskCancellation", testLongTaskCancellation),
+    ]
+}
+
+extension DeterminedTests {
+    static let __allTests = [
+        ("testEquals1", testEquals1),
+        ("testEquals2", testEquals2),
+        ("testGetters", testGetters),
+    ]
+}
+
+extension DispatchUtilitiesTests {
+    static let __allTests = [
+        ("testCurrent", testCurrent),
+        ("testQoS", testQoS),
+        ("testQoSClass", testQoSClass),
+    ]
+}
+
+extension TBDTests {
+    static let __allTests = [
+        ("testCancel", testCancel),
+        ("testDetermine1", testDetermine1),
+        ("testDetermine2", testDetermine2),
+        ("testNeverDetermined", testNeverDetermined),
+        ("testNotify1", testNotify1),
+        ("testNotify2", testNotify2),
+        ("testNotify3", testNotify3),
+        ("testNotify4", testNotify4),
+        ("testParallel1", testParallel1),
+        ("testParallel2", testParallel2),
+        ("testParallel3", testParallel3),
+        ("testParallel4", testParallel4),
+    ]
+}
+
+extension TBDTimingTests {
+    static let __allTests = [
+        ("testPerformanceNotificationTime", testPerformanceNotificationTime),
+        ("testPerformancePropagationTime", testPerformancePropagationTime),
+    ]
+}
+
+#if !os(macOS)
+public func __allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(DeferredCombinationTests.__allTests),
+        testCase(DeferredCombinationTimedTests.__allTests),
+        testCase(DeferredTests.__allTests),
+        testCase(DeletionTests.__allTests),
+        testCase(DeterminedTests.__allTests),
+        testCase(DispatchUtilitiesTests.__allTests),
+        testCase(TBDTests.__allTests),
+        testCase(TBDTimingTests.__allTests),
+    ]
+}
+#endif

--- a/Xcode/deferred.xcodeproj/project.pbxproj
+++ b/Xcode/deferred.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		03B7768920CAECFC00F4B44B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		03B7768E20CAECFC00F4B44B /* deferredTestTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = deferredTestTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		03B7769420CAECFC00F4B44B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		03BEA0DF20CF3C1200F4B44B /* XCTestManifests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = XCTestManifests.swift; path = deferredTests/XCTestManifests.swift; sourceTree = "<group>"; };
 		03D59CB31F7B6CB900F4B44B /* determined.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = determined.swift; path = deferred/determined.swift; sourceTree = "<group>"; };
 		03D5D7891E52339C00F4B44B /* dispatch-utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "dispatch-utilities.swift"; path = "deferred/dispatch-utilities.swift"; sourceTree = "<group>"; };
 		03E8795A1F6C98ED00F4B44B /* DispatchUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DispatchUtilitiesTests.swift; path = deferredTests/DispatchUtilitiesTests.swift; sourceTree = "<group>"; };
@@ -260,6 +261,7 @@
 				03E8795A1F6C98ED00F4B44B /* DispatchUtilitiesTests.swift */,
 				0366AE541DF0FEC400F4B44B /* TestError.swift */,
 				0374DFB01DFF5BD800F4B44B /* nzRandom.swift */,
+				03BEA0DF20CF3C1200F4B44B /* XCTestManifests.swift */,
 			);
 			name = Tests;
 			path = ../Tests;
@@ -369,6 +371,7 @@
 			buildConfigurationList = 03B4E0811C14003C00F4B44B /* Build configuration list for PBXNativeTarget "deferred-tests" */;
 			buildPhases = (
 				03B4E0721C14003C00F4B44B /* Sources */,
+				03BEA0DB20CF38C100F4B44B /* ShellScript */,
 				03B4E0731C14003C00F4B44B /* Frameworks */,
 				03B4E0741C14003C00F4B44B /* Resources */,
 			);
@@ -544,6 +547,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		03BEA0DB20CF38C100F4B44B /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "testdir=\"../Tests/deferredTests\"\nmanifest=\"XCTestManifests.swift\"\nnewer=`/usr/bin/find $testdir -newer $testdir/$manifest`\nif /bin/test ! -e $testdir/$manifest -o ! -z $newer\nthen\n    /usr/bin/swift test --generate-linuxmain\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		03B4E0681C14003B00F4B44B /* Sources */ = {


### PR DESCRIPTION
rely on an auto-generated list of tests courtesy of swiftpm,
rather than continually fail to update the list by hand.