### PR TITLE
minor changes

### DIFF
--- a/Source/deferred/deferred-timing.swift
+++ b/Source/deferred/deferred-timing.swift
@@ -45,8 +45,8 @@ extension Deferred
   /// - returns: a `Deferred` reference
 
   public func delay(queue: DispatchQueue? = nil, until time: DispatchTime) -> Deferred
-  { // FIXME: don't special-case .distantFuture (https://bugs.swift.org/browse/SR-5706)
-    guard time > .now() || time == .distantFuture else { return self }
+  {
+    guard time > .now() else { return self }
     return Delay(queue: queue, source: self, until: time)
   }
 }

--- a/Source/deferred/deferred.swift
+++ b/Source/deferred/deferred.swift
@@ -697,8 +697,7 @@ class Delay<Value>: Deferred<Value>
 
     source.enqueue(queue: queue, boostQoS: false) {
       [weak self] outcome in
-      guard let this = self else { return }
-      if this.isDetermined { return }
+      guard let this = self, (this.isDetermined == false) else { return }
 
       if outcome.isError
       {

--- a/Source/deferred/dispatch-utilities.swift
+++ b/Source/deferred/dispatch-utilities.swift
@@ -14,11 +14,9 @@ extension DispatchQoS
 {
   static public var current: DispatchQoS
   {
-    if let qosClass = DispatchQoS.QoSClass.current
-    {
-      return DispatchQoS(qosClass: qosClass, relativePriority: 0)
-    }
-    return .default
+    guard let qosClass = DispatchQoS.QoSClass.current
+      else { return .default }
+    return DispatchQoS(qosClass: qosClass, relativePriority: 0)
   }
 }
 

--- a/Source/deferred/waiter.swift
+++ b/Source/deferred/waiter.swift
@@ -64,18 +64,16 @@ func deallocateWaiters<T>(_ tail: UnsafeMutablePointer<Waiter<T>>?)
 
 private func reverseList<T>(_ tail: UnsafeMutablePointer<Waiter<T>>?) -> UnsafeMutablePointer<Waiter<T>>?
 {
-  if tail != nil && tail!.pointee.next != nil
-  {
-    var head: UnsafeMutablePointer<Waiter<T>>? = nil
-    var current = tail
-    while let element = current
-    {
-      current = element.pointee.next
+  if tail?.pointee.next == nil { return tail }
 
-      element.pointee.next = head
-      head = element
-    }
-    return head
+  var head: UnsafeMutablePointer<Waiter<T>>? = nil
+  var current = tail
+  while let element = current
+  {
+    current = element.pointee.next
+
+    element.pointee.next = head
+    head = element
   }
-  return tail
+  return head
 }

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -515,6 +515,21 @@ class DeferredTests: XCTestCase
     waitForExpectations(timeout: 0.1)
   }
 
+  func testTransfer()
+  {
+    let r1 = nzRandom()
+    let r2 = nzRandom()
+
+    let transferred1 = Transferred(from: Deferred(value: r1))
+
+    let tbd = TBD<Int>(qos: .background)
+    let transferred2 = Transferred(from: tbd)
+    tbd.determine(r2)
+
+    XCTAssert(transferred1.value == r1)
+    XCTAssert(transferred2.value == r2)
+  }
+
   func testApply()
   {
     // a simple curried function.

--- a/Tests/deferredTests/XCTestManifests.swift
+++ b/Tests/deferredTests/XCTestManifests.swift
@@ -37,7 +37,6 @@ extension DeferredTests {
         ("testCancelDelay", testCancelDelay),
         ("testCancelMap", testCancelMap),
         ("testDeferredError", testDeferredError),
-        ("testDelay", testDelay),
         ("testExample", testExample),
         ("testExample2", testExample2),
         ("testExample3", testExample3),
@@ -64,6 +63,18 @@ extension DeferredTests {
         ("testValue", testValue),
         ("testValueBlocks", testValueBlocks),
         ("testValueUnblocks", testValueUnblocks),
+    ]
+}
+
+extension DelayTests {
+    static let __allTests = [
+        ("testAbandonedDelay", testAbandonedDelay),
+        ("testCancelDelay", testCancelDelay),
+        ("testDelayError", testDelayError),
+        ("testDelayValue", testDelayValue),
+        ("testDistantFuture", testDistantFuture),
+        ("testDistantFutureDelay", testDistantFutureDelay),
+        ("testSourceSlowerThanDelay", testSourceSlowerThanDelay),
     ]
 }
 
@@ -116,6 +127,7 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(DeferredCombinationTests.__allTests),
         testCase(DeferredCombinationTimedTests.__allTests),
         testCase(DeferredTests.__allTests),
+        testCase(DelayTests.__allTests),
         testCase(DeletionTests.__allTests),
         testCase(DispatchUtilitiesTests.__allTests),
         testCase(TBDTests.__allTests),

--- a/Tests/deferredTests/XCTestManifests.swift
+++ b/Tests/deferredTests/XCTestManifests.swift
@@ -58,6 +58,7 @@ extension DeferredTests {
         ("testRetryTask", testRetryTask),
         ("testState", testState),
         ("testTimeout", testTimeout),
+        ("testTransfer", testTransfer),
         ("testValidate1", testValidate1),
         ("testValidate2", testValidate2),
         ("testValue", testValue),


### PR DESCRIPTION
• remove DispatchTime.distantFuture comparison workaround (requires Swift 4.0.2 on Linux)
• separate out tests of Delay to hopefully make clearer what is tested
• explicit test of Transferred
• minor tweaks
