### PR TITLE
require parameter label to determine with an Error

### DIFF
--- a/Source/deferred/deferred-first.swift
+++ b/Source/deferred/deferred-first.swift
@@ -178,7 +178,7 @@ public func firstDetermined<Value, C: Collection>(queue: DispatchQueue,
 
   deferreds.forEach {
     deferred in
-    deferred.notify { _ in first.determine(deferred) }
+    deferred.notify { _ in first.determine(value: deferred) }
     if cancelOthers { first.notify { _ in deferred.cancel() } }
   }
 
@@ -244,14 +244,14 @@ public func firstDetermined<Value, S>(queue: DispatchQueue, deferreds: S,
     deferreds.forEach {
       deferred in
       subscribed = true
-      deferred.notify { _ in first.determine(deferred) }
+      deferred.notify { _ in first.determine(value: deferred) }
       if cancelOthers { first.notify { _ in deferred.cancel() } }
     }
 
     if !subscribed
     {
       let error = DeferredError.invalid("cannot find first determined from an empty set in \(#function)")
-      first.determine(error)
+      first.determine(error: error)
     }
   }
 

--- a/Source/deferred/deferred-parallelize.swift
+++ b/Source/deferred/deferred-parallelize.swift
@@ -82,10 +82,10 @@ extension Collection
         let index = self.index(self.startIndex, offsetBy: Distance(iteration))
         do {
           let value = try task(self[index])
-          deferreds[iteration].determine(value)
+          deferreds[iteration].determine(value: value)
         }
         catch {
-          deferreds[iteration].determine(error)
+          deferreds[iteration].determine(error: error)
         }
       }
     }

--- a/Source/deferred/nsurlsession.swift
+++ b/Source/deferred/nsurlsession.swift
@@ -81,7 +81,7 @@ public extension URLSession
 
       if let error = error
       {
-        tbd.determine(error)
+        tbd.determine(error: error)
         return
       }
 
@@ -91,7 +91,7 @@ public extension URLSession
         return
       }
       // Probably an impossible situation
-      tbd.determine(URLSessionError.InvalidState)
+      tbd.determine(error: URLSessionError.InvalidState)
     }
   }
 
@@ -104,7 +104,7 @@ public extension URLSession
        scheme != "http" && scheme != "https"
     {
       let message = "deferred does not support url scheme \"\(request.url?.scheme! ?? "unknown")\""
-      tbd.determine(DeferredError.invalid(message))
+      tbd.determine(error: DeferredError.invalid(message))
     }
 
     let task = dataTask(with: request, completionHandler: dataCompletion(tbd))
@@ -126,7 +126,7 @@ public extension URLSession
        scheme != "http" && scheme != "https"
     {
       let message = "deferred does not support url scheme \"\(request.url?.scheme! ?? "unknown")\""
-      tbd.determine(DeferredError.invalid(message))
+      tbd.determine(error: DeferredError.invalid(message))
     }
 
     let task = uploadTask(with: request, from: bodyData, completionHandler: dataCompletion(tbd))
@@ -142,7 +142,7 @@ public extension URLSession
        scheme != "http" && scheme != "https"
     {
       let message = "deferred does not support url scheme \"\(request.url?.scheme! ?? "unknown")\""
-      tbd.determine(DeferredError.invalid(message))
+      tbd.determine(error: DeferredError.invalid(message))
     }
 
     let task = uploadTask(with: request, fromFile: fileURL, completionHandler: dataCompletion(tbd))
@@ -188,12 +188,12 @@ extension URLSession
           let URLSessionDownloadTaskResumeData = NSURLSessionDownloadTaskResumeData
 #endif
           if let data = error.userInfo[URLSessionDownloadTaskResumeData] as? Data
-          { tbd.determine(URLSessionError.InterruptedDownload(error, data)) }
+          { tbd.determine(error: URLSessionError.InterruptedDownload(error, data)) }
           else
-          { tbd.determine(DeferredError.canceled(error.localizedDescription)) }
+          { tbd.determine(error: DeferredError.canceled(error.localizedDescription)) }
         }
         else
-        { tbd.determine(error) }
+        { tbd.determine(error: error) }
         return
       }
 
@@ -205,12 +205,12 @@ extension URLSession
         }
         catch {
           // Likely an impossible situation
-          tbd.determine(error)
+          tbd.determine(error: error)
         }
         return
       }
       // Probably an impossible situation
-      tbd.determine(URLSessionError.InvalidState)
+      tbd.determine(error: URLSessionError.InvalidState)
     }
   }
 
@@ -223,7 +223,7 @@ extension URLSession
        scheme != "http" && scheme != "https"
     {
       let message = "deferred does not support url scheme \"\(request.url?.scheme! ?? "unknown")\""
-      tbd.determine(DeferredError.invalid(message))
+      tbd.determine(error: DeferredError.invalid(message))
     }
 
     let task = downloadTask(with: request, completionHandler: downloadCompletion(tbd))

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -452,7 +452,7 @@ class DeferredTests: XCTestCase
     let d4 = badOperand2.flatten()
     let e4 = expectation(description: "flatten, part 4")
     d4.recover(transform: { Deferred(error: $0) }).onError(task: { _ in e4.fulfill() })
-    badOperand2.determine(TestError(error))
+    badOperand2.determine(error: TestError(error))
 
     let tbd = TBD<Int>()
     let fullyDeferred = Deferred(value: tbd.delay(seconds: 0.02)).delay(seconds: 0.01)
@@ -531,7 +531,7 @@ class DeferredTests: XCTestCase
 
     g.notify { _ in
       v1 = Int(nzRandom() & 0x7fff + 10000)
-      transform.determine { i in Double(v1*i) }
+      transform.determine(value: { i in Double(v1*i) })
     }
 
     g.notify { _ in

--- a/Tests/deferredTests/TBDTests.swift
+++ b/Tests/deferredTests/TBDTests.swift
@@ -27,7 +27,7 @@ class TBDTests: XCTestCase
 
     let tbe = TBD<Void>()
     tbe.beginExecution()
-    XCTAssert(tbe.determine(TestError(value)))
+    XCTAssert(tbe.determine(error: TestError(value)))
     XCTAssert(tbe.isDetermined)
     XCTAssert(tbe.value == nil)
     XCTAssert(tbe.error as? TestError == TestError(value))


### PR DESCRIPTION
- in the absence of a label, it is just too painful to use
  a `Determined<Error>`.
- also adds a determine(value:), but leaves an overloaded
  unlabelled determined(_:) for the success path