### PR TITLE
change firstValue to return the earliest successful outcome

### DIFF
--- a/Tests/deferredTests/TestError.swift
+++ b/Tests/deferredTests/TestError.swift
@@ -6,13 +6,21 @@
 //  Copyright © 2015 Guillaume Lessard. All rights reserved.
 //
 
-struct TestError: Error, Equatable
+enum TestError: Error, Equatable
 {
-  let error: Int
-  init(_ e: Int = 0) { error = e }
+  case value(Int)
+
+  var error: Int {
+    switch self { case .value(let v): return v }
+  }
+
+  init(_ e: Int = 0) { self = .value(e) }
 }
 
 func == (l: TestError, r: TestError) -> Bool
 {
-  return l.error == r.error
+  switch (l,r)
+  {
+  case let (.value(lv), .value(rv)): return lv == rv
+  }
 }

--- a/Tests/deferredTests/XCTestManifests.swift
+++ b/Tests/deferredTests/XCTestManifests.swift
@@ -7,10 +7,6 @@ extension DeferredCombinationTests {
         ("testCombine4", testCombine4),
         ("testCombineArray1", testCombineArray1),
         ("testCombineArray2", testCombineArray2),
-        ("testFirstDeterminedCollection", testFirstDeterminedCollection),
-        ("testFirstDeterminedSequence", testFirstDeterminedSequence),
-        ("testFirstValueCollection", testFirstValueCollection),
-        ("testFirstValueSequence", testFirstValueSequence),
         ("testReduce", testReduce),
         ("testReduceCancel", testReduceCancel),
     ]
@@ -21,6 +17,19 @@ extension DeferredCombinationTimedTests {
         ("testPerformanceABAProneReduce", testPerformanceABAProneReduce),
         ("testPerformanceCombine", testPerformanceCombine),
         ("testPerformanceReduce", testPerformanceReduce),
+    ]
+}
+
+extension DeferredRacingTests {
+    static let __allTests = [
+        ("testFirstDeterminedCollection", testFirstDeterminedCollection),
+        ("testFirstDeterminedSequence", testFirstDeterminedSequence),
+        ("testFirstValueCollection", testFirstValueCollection),
+        ("testFirstValueCollectionError", testFirstValueCollectionError),
+        ("testFirstValueEmptyCollection", testFirstValueEmptyCollection),
+        ("testFirstValueEmptySequence", testFirstValueEmptySequence),
+        ("testFirstValueSequence", testFirstValueSequence),
+        ("testFirstValueSequenceError", testFirstValueSequenceError),
     ]
 }
 
@@ -126,6 +135,7 @@ public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(DeferredCombinationTests.__allTests),
         testCase(DeferredCombinationTimedTests.__allTests),
+        testCase(DeferredRacingTests.__allTests),
         testCase(DeferredTests.__allTests),
         testCase(DelayTests.__allTests),
         testCase(DeletionTests.__allTests),


### PR DESCRIPTION
it is a change in behaviour, even though it doesn't change the call sites. (sorry)