### PR TITLE
add a deprecation warning

### DIFF
--- a/Source/deferred/deferred.swift
+++ b/Source/deferred/deferred.swift
@@ -816,6 +816,7 @@ open class TBD<Value>: Deferred<Value>
   /// - returns: whether the call succesfully changed the state of this `Deferred`.
 
   @discardableResult
+  @available(*, deprecated, renamed: "determine(value:)")
   public final func determine(_ value: Value) -> Bool
   {
     return determine(value: value)

--- a/Source/deferred/nsurlsession.swift
+++ b/Source/deferred/nsurlsession.swift
@@ -87,7 +87,7 @@ public extension URLSession
 
       if let d = data, let r = response as? HTTPURLResponse
       {
-        tbd.determine( (d,r) )
+        tbd.determine(value: (d,r))
         return
       }
       // Probably an impossible situation
@@ -201,7 +201,7 @@ extension URLSession
       {
         do {
           let f = try FileHandle(forReadingFrom: u)
-          tbd.determine( (u,f,r) )
+          tbd.determine(value: (u,f,r))
         }
         catch {
           // Likely an impossible situation

--- a/Tests/deferredTests/DeferredCombinationTests.swift
+++ b/Tests/deferredTests/DeferredCombinationTests.swift
@@ -180,7 +180,7 @@ class DeferredCombinationTests: XCTestCase
     }
     let first = firstValue(deferreds, cancelOthers: true)
 
-    XCTAssert(deferreds[lucky].determine(lucky))
+    XCTAssert(deferreds[lucky].determine(value: lucky))
     waitForExpectations(timeout: 0.1)
     XCTAssert(first.value == lucky)
 

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -446,7 +446,7 @@ class DeferredTests: XCTestCase
     let d3 = deferredValue.flatten()
     let e3 = expectation(description: "flatten, part 3")
     d3.validate(predicate: { XCTAssertEqual($0, value) }).onValue(task: { _ in e3.fulfill() })
-    deferredValue.determine(Deferred(value: value))
+    deferredValue.determine(value: Deferred(value: value))
 
     let badOperand2 = TBD<Deferred<Int>>()
     let d4 = badOperand2.flatten()
@@ -468,7 +468,7 @@ class DeferredTests: XCTestCase
 //    let willCompile = Deferred(value: d1).flatten()
 //    let wontCompile = Deferred(value: 99).flatten()
 
-    tbd.determine(value)
+    tbd.determine(value: value)
 
     waitForExpectations(timeout: 0.1)
   }
@@ -482,7 +482,7 @@ class DeferredTests: XCTestCase
 
     let tbd = TBD<Int>(qos: .background)
     let transferred2 = Transferred(from: tbd)
-    tbd.determine(r2)
+    tbd.determine(value: r2)
 
     XCTAssert(transferred1.value == r1)
     XCTAssert(transferred2.value == r2)
@@ -536,7 +536,7 @@ class DeferredTests: XCTestCase
 
     g.notify { _ in
       v2 = Int(nzRandom() & 0x7fff + 10000)
-      operand.determine(v2)
+      operand.determine(value: v2)
     }
 
     XCTAssertFalse(operand.isDetermined)
@@ -544,7 +544,7 @@ class DeferredTests: XCTestCase
     XCTAssertFalse(transform.isDetermined)
     XCTAssert(transform.state == .waiting)
 
-    g.determine(0)
+    g.determine(value: 0)
     waitForExpectations(timeout: 1.0)
 
     XCTAssert(transform.state == .succeeded)
@@ -606,7 +606,7 @@ class DeferredTests: XCTestCase
     let r5 = o5.apply(transform: t5)
     combine(t5,r5).notify { _ in e5.fulfill() }
     r5.cancel()
-    t5.determine({ Float($0) })
+    t5.determine(value: { Float($0) })
     XCTAssert(r5.value == nil)
     XCTAssert(r5.error as? DeferredError == DeferredError.canceled(""))
 
@@ -729,7 +729,7 @@ class DeferredTests: XCTestCase
     d2.onError { e in e2.fulfill() }
     XCTAssert(d2.cancel() == true)
 
-    tbd.determine(numericCast(nzRandom()))
+    tbd.determine(value: numericCast(nzRandom()))
 
     waitForExpectations(timeout: 1.0)
   }
@@ -743,7 +743,7 @@ class DeferredTests: XCTestCase
     d1.onError { e in e1.fulfill() }
     XCTAssert(d1.cancel() == true)
 
-    tbd.determine(numericCast(nzRandom()))
+    tbd.determine(value: numericCast(nzRandom()))
 
     waitForExpectations(timeout: 1.0)
   }
@@ -772,7 +772,7 @@ class DeferredTests: XCTestCase
     d4.onError { e in e4.fulfill() }
     XCTAssert(d4.cancel() == true)
 
-    tbd.determine(numericCast(nzRandom()))
+    tbd.determine(value: numericCast(nzRandom()))
 
     waitForExpectations(timeout: 1.0)
   }
@@ -807,7 +807,7 @@ class DeferredTests: XCTestCase
     XCTAssert(d3.cancel() == true)
     XCTAssert(d4.cancel() == true)
 
-    tbd.determine(numericCast(nzRandom()))
+    tbd.determine(value: numericCast(nzRandom()))
 
     waitForExpectations(timeout: 1.0)
   }

--- a/Tests/deferredTests/TBDTests.swift
+++ b/Tests/deferredTests/TBDTests.swift
@@ -20,7 +20,7 @@ class TBDTests: XCTestCase
     let tbd = TBD<Int>()
     tbd.beginExecution()
     let value = nzRandom()
-    XCTAssert(tbd.determine(value))
+    XCTAssert(tbd.determine(value: value))
     XCTAssert(tbd.isDetermined)
     XCTAssert(tbd.value == value)
     XCTAssert(tbd.error == nil)
@@ -40,7 +40,7 @@ class TBDTests: XCTestCase
     var value = nzRandom()
     DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + 0.01) {
       value = nzRandom()
-      XCTAssert(tbd.determine(value))
+      XCTAssert(tbd.determine(value: value))
     }
 
     XCTAssert(tbd.isDetermined == false)
@@ -50,7 +50,7 @@ class TBDTests: XCTestCase
     XCTAssert(tbd.error == nil)
 
     // Try and fail to determine tbd a second time.
-    XCTAssert(tbd.determine(value) == false)
+    XCTAssert(tbd.determine(value: value) == false)
   }
 
   func testCancel() throws
@@ -69,7 +69,7 @@ class TBDTests: XCTestCase
     let tbd3 = TBD<Int>()
     DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + 0.1) { XCTAssert(tbd3.cancel() == true) }
     DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + 0.2) {
-      if tbd3.determine(nzRandom())
+      if tbd3.determine(value: nzRandom())
       {
         XCTFail()
       }
@@ -87,7 +87,7 @@ class TBDTests: XCTestCase
     let value = nzRandom()
     let e1 = expectation(description: "TBD notification after determination")
     let tbd = TBD<Int>()
-    tbd.determine(value)
+    tbd.determine(value: value)
 
     tbd.notify {
       XCTAssert( $0.value == value )
@@ -109,7 +109,7 @@ class TBDTests: XCTestCase
 
     DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + 10e-6) {
       value = nzRandom()
-      XCTAssert(tbd.determine(value))
+      XCTAssert(tbd.determine(value: value))
     }
 
     waitForExpectations(timeout: 1.0)
@@ -144,7 +144,7 @@ class TBDTests: XCTestCase
       if d.value == r { e.fulfill() }
     }
 
-    d1.determine(r)
+    d1.determine(value: r)
 
     waitForExpectations(timeout: 0.1)
   }

--- a/Tests/deferredTests/TBDTimingTests.swift
+++ b/Tests/deferredTests/TBDTimingTests.swift
@@ -34,7 +34,7 @@ class TBDTimingTests: XCTestCase
         }
       }
 
-      first.determine( (0, ref, ref) )
+      first.determine(value: (0, ref, ref))
 
       let (iterations, tic, toc) = try! dt.get()
       let interval = toc.timeIntervalSince(tic)
@@ -55,7 +55,7 @@ class TBDTimingTests: XCTestCase
       }
 
       let dt = start.map { start in Date().timeIntervalSince(start) }
-      start.determine(Date())
+      start.determine(value: Date())
 
       let interval = try! dt.get()
       // print("\(round(Double(interval*1e9)/Double(iterations))/1000) µs per notification")


### PR DESCRIPTION
`TBD.determine(_ value: Value)` renamed to `TBD.determine(value: Value)`