### PR TITLE
improve TBD

### DIFF
--- a/Tests/deferredTests/DeferredCombinationTests.swift
+++ b/Tests/deferredTests/DeferredCombinationTests.swift
@@ -174,16 +174,19 @@ class DeferredRacingTests: XCTestCase
     let count = 10
     let lucky = Int(nzRandom()) % count
 
+    var injectors: [Injector<Int>] = []
     let deferreds = (0..<count).map {
-      i -> TBD<Int> in
+      i -> Deferred<Int> in
       let e = expectation(description: String(i))
-      let d = TBD<Int>()
-      d.notify { _ in e.fulfill() }
-      return d
+      return TBD<Int>() {
+        d in
+        d.notify { _ in e.fulfill() }
+        injectors.append(d)
+      }
     }
     let first = firstValue(deferreds, cancelOthers: true)
 
-    XCTAssert(deferreds[lucky].determine(value: lucky))
+    XCTAssert(injectors[lucky].determine(value: lucky))
     waitForExpectations(timeout: 0.1)
     XCTAssert(first.value == lucky)
 

--- a/Tests/deferredTests/DeletionTests.swift
+++ b/Tests/deferredTests/DeletionTests.swift
@@ -35,7 +35,7 @@ class DeletionTests: XCTestCase
     init(expectation: XCTestExpectation)
     {
       e = expectation
-      super.init(queue: DispatchQueue.global())
+      super.init(queue: .global()) { _ in }
     }
     deinit
     {

--- a/Tests/deferredTests/TestError.swift
+++ b/Tests/deferredTests/TestError.swift
@@ -16,3 +16,9 @@ enum TestError: Error, Equatable
 
   init(_ e: Int = 0) { self = .value(e) }
 }
+
+func == (l: Error?, r: TestError) -> Bool
+{
+  guard let e = l as? TestError else { return false }
+  return e == r
+}

--- a/Tests/deferredTests/URLSessionTests.swift
+++ b/Tests/deferredTests/URLSessionTests.swift
@@ -200,7 +200,7 @@ extension URLSessionTests
       return session.deferredDataTask(with: unavailableURL)
     }()
 
-    deferred.urlSessionTask.cancel()
+    deferred.urlSessionTask?.cancel()
 
     do {
       let _ = try deferred.get()
@@ -219,7 +219,7 @@ extension URLSessionTests
     let session = URLSession(configuration: .default)
 
     let deferred = session.deferredDataTask(with: unavailableURL)
-    deferred.urlSessionTask.suspend()
+    deferred.urlSessionTask?.suspend()
     let canceled = deferred.cancel()
     XCTAssert(canceled)
 
@@ -265,7 +265,7 @@ extension URLSessionTests
       return session.deferredDownloadTask(with: unavailableURL)
     }()
 
-    deferred.urlSessionTask.cancel()
+    deferred.urlSessionTask?.cancel()
 
     do {
       let _ = try deferred.get()
@@ -284,7 +284,7 @@ extension URLSessionTests
     let session = URLSession(configuration: .default)
 
     let deferred = session.deferredDownloadTask(with: unavailableURL)
-    deferred.urlSessionTask.suspend()
+    deferred.urlSessionTask?.suspend()
     let canceled = deferred.cancel()
     XCTAssert(canceled)
 


### PR DESCRIPTION
The original design of `TBD` introduced a hazard wherein any code that held a reference to one also had the ability to `determine` its outcome. This new design uses an always-executed, non-escaping closure which obtains an `Injector` as a parameter. The `Injector` can be used to `determine` the outcome of the `TBD`, and this allows the `TBD` to have no API besides that provided by `Deferred`.