### PR TITLE
Sources as waiters

### DIFF
--- a/Source/deferred/deferred-extras.swift
+++ b/Source/deferred/deferred-extras.swift
@@ -77,10 +77,11 @@ extension Deferred
       return Deferred(queue: queue, result: result)
     }
 
-    return TBD(queue: queue, source: self) {
+    return TBD(queue: queue) {
       resolver in
       if self.state == .executing { resolver.beginExecution() }
       self.enqueue(queue: queue, boostQoS: false, task: { resolver.resolve($0) })
+      resolver.retainSource(self)
     }
   }
 
@@ -112,7 +113,7 @@ extension Deferred
   public func map<Other>(queue: DispatchQueue? = nil,
                          transform: @escaping (_ value: Value) throws -> Other) -> Deferred<Other>
   {
-    return TBD(queue: queue ?? self.queue, source: self) {
+    return TBD(queue: queue ?? self.queue) {
       resolver in
       self.enqueue(queue: queue) {
         result in
@@ -127,6 +128,7 @@ extension Deferred
           resolver.resolve(error: error)
         }
       }
+      resolver.retainSource(self)
     }
   }
 
@@ -159,7 +161,7 @@ extension Deferred
   public func flatMap<Other>(queue: DispatchQueue? = nil,
                              transform: @escaping (_ value: Value) throws -> Deferred<Other>) -> Deferred<Other>
   {
-    return TBD(queue: queue ?? self.queue, source: self) {
+    return TBD(queue: queue ?? self.queue) {
       resolver in
       self.enqueue(queue: queue) {
         result in
@@ -182,6 +184,7 @@ extension Deferred
           resolver.resolve(error: error)
         }
       }
+      resolver.retainSource(self)
     }
   }
 
@@ -209,7 +212,7 @@ extension Deferred
   public func recover(queue: DispatchQueue? = nil,
                       transform: @escaping (_ error: Error) throws -> Deferred<Value>) -> Deferred<Value>
   {
-    return TBD(queue: queue ?? self.queue, source: self) {
+    return TBD(queue: queue ?? self.queue) {
       resolver in
       self.enqueue(queue: queue) {
         result in
@@ -238,6 +241,7 @@ extension Deferred
           resolver.resolve(result)
         }
       }
+      resolver.retainSource(self)
     }
   }
 
@@ -283,7 +287,7 @@ extension Deferred
         return Deferred<Other>(queue: queue ?? self.queue, result: result)
       }
 
-      return TBD(queue: queue ?? self.queue, source: deferred) {
+      return TBD(queue: queue ?? self.queue) {
         resolver in
         if deferred.state == .executing { resolver.beginExecution() }
         deferred.enqueue(queue: queue) { resolver.resolve($0) }
@@ -291,7 +295,7 @@ extension Deferred
       }
     }
 
-    return TBD(queue: queue ?? self.queue, source: self) {
+    return TBD(queue: queue ?? self.queue) {
       resolver in
       self.enqueue(queue: queue) {
         result in
@@ -315,6 +319,7 @@ extension Deferred
         deferred.enqueue(queue: queue) { resolver.resolve($0) }
         resolver.retainSource(deferred)
       }
+      resolver.retainSource(self)
     }
   }
 }
@@ -431,7 +436,7 @@ extension Deferred
       }
     }
 
-    return TBD(queue: queue ?? self.queue, source: self) {
+    return TBD(queue: queue ?? self.queue) {
       resolver in
       self.enqueue(queue: queue) {
         result in
@@ -452,6 +457,7 @@ extension Deferred
           resolver.resolve(error: error)
         }
       }
+      resolver.retainSource(self)
     }
   }
 

--- a/Source/deferred/deferred-extras.swift
+++ b/Source/deferred/deferred-extras.swift
@@ -175,8 +175,7 @@ extension Deferred
           else
           {
             transformed.enqueue(queue: queue) { resolver.resolve($0) }
-            // ensure `transformed` lives as long as it needs to
-            resolver.notify { _ in withExtendedLifetime(transformed, {}) }
+            resolver.retainSource(transformed)
           }
         }
         catch {
@@ -227,8 +226,7 @@ extension Deferred
             else
             {
               transformed.enqueue(queue: queue) { resolver.resolve($0) }
-              // ensure `transformed` lives as long as it needs to
-              resolver.notify { _ in withExtendedLifetime(transformed, {}) }
+              resolver.retainSource(transformed)
             }
           }
           catch {
@@ -289,8 +287,7 @@ extension Deferred
         resolver in
         if deferred.state == .executing { resolver.beginExecution() }
         deferred.enqueue(queue: queue) { resolver.resolve($0) }
-        // ensure `deferred` lives as long as it needs to
-        resolver.notify { _ in withExtendedLifetime(deferred, {}) }
+        resolver.retainSource(deferred)
       }
     }
 
@@ -316,8 +313,7 @@ extension Deferred
 
         if deferred.state == .executing { resolver.beginExecution() }
         deferred.enqueue(queue: queue) { resolver.resolve($0) }
-        // ensure `deferred` lives as long as it needs to
-        resolver.notify { _ in withExtendedLifetime(deferred, {}) }
+        resolver.retainSource(deferred)
       }
     }
   }
@@ -449,8 +445,7 @@ extension Deferred
           else
           {
             transform.enqueue(queue: queue) { applyTransform(value, $0, resolver) }
-            // ensure `transform` lives as long as it needs to
-            resolver.notify { _ in withExtendedLifetime(transform, {}) }
+            resolver.retainSource(transform)
           }
         }
         catch {

--- a/Source/deferred/deferred-timing.swift
+++ b/Source/deferred/deferred-timing.swift
@@ -51,7 +51,7 @@ extension Deferred
   {
     guard time > .now() else { return self }
 
-    return TBD(queue: queue ?? self.queue, source: self) {
+    return TBD(queue: queue ?? self.queue) {
       resolver in
       self.enqueue(queue: queue, boostQoS: false) {
         result in
@@ -77,6 +77,7 @@ extension Deferred
           resolver.resolve(result)
         }
       }
+      resolver.retainSource(self)
     }
   }
 }

--- a/Source/deferred/deferred.swift
+++ b/Source/deferred/deferred.swift
@@ -533,6 +533,11 @@ public struct Resolver<Value>
   {
     deferred?.enqueue(task: task)
   }
+
+  public func retainSource(_ object: AnyObject)
+  {
+    deferred?.enqueue(task: { _ in withExtendedLifetime(object, {}) } )
+  }
 }
 
 /// A `Deferred` to be resolved (`TBD`) manually.

--- a/Source/deferred/deferred.swift
+++ b/Source/deferred/deferred.swift
@@ -52,7 +52,6 @@ private extension Int
 open class Deferred<Value>
 {
   let queue: DispatchQueue
-  private var source: AnyObject?
 
   private var resolved: Result<Value, Error>?
   private var deferredState: AtomicInt
@@ -68,10 +67,9 @@ open class Deferred<Value>
 
   // MARK: designated initializers
 
-  fileprivate init(queue: DispatchQueue, source: AnyObject? = nil)
+  fileprivate init(queue: DispatchQueue)
   {
     self.queue = queue
-    self.source = source
     resolved = nil
     deferredState = AtomicInt(.waiting)
   }
@@ -84,7 +82,6 @@ open class Deferred<Value>
   public init(queue: DispatchQueue, result: Result<Value, Error>)
   {
     self.queue = queue
-    source = nil
     resolved = result
     deferredState = AtomicInt(.resolved)
   }
@@ -97,7 +94,6 @@ open class Deferred<Value>
   public init(queue: DispatchQueue, task: @escaping () throws -> Value)
   {
     self.queue = queue
-    source = nil
     resolved = nil
     deferredState = AtomicInt(.executing)
 
@@ -203,7 +199,6 @@ open class Deferred<Value>
     // this thread has exclusive access
 
     resolved = result
-    source = nil
 
     // This atomic swap operation uses memory order .acqrel.
     // "release" ordering ensures visibility of changes to `resolved` above to another thread.
@@ -571,9 +566,9 @@ open class TBD<Value>: Deferred<Value>
   ///
   /// - parameter queue: the `DispatchQueue` on which the notifications will be executed
 
-  public init(queue: DispatchQueue, source: AnyObject? = nil, task: (Resolver<Value>) -> Void)
+  public init(queue: DispatchQueue, task: (Resolver<Value>) -> Void)
   {
-    super.init(queue: queue, source: source)
+    super.init(queue: queue)
     task(Resolver(self))
   }
 
@@ -581,10 +576,10 @@ open class TBD<Value>: Deferred<Value>
   ///
   /// - parameter qos: the QoS at which the notifications should be performed; defaults to the current QoS class.
 
-  public init(qos: DispatchQoS = .current, source: AnyObject? = nil, task: (Resolver<Value>) -> Void)
+  public init(qos: DispatchQoS = .current, task: (Resolver<Value>) -> Void)
   {
     let queue = DispatchQueue(label: "tbd", qos: qos)
-    super.init(queue: queue, source: source)
+    super.init(queue: queue)
     task(Resolver(self))
   }
 


### PR DESCRIPTION
Make retained sources part of the same linked list as notification closures.

This allows for cases where more than one retained source is relevant, without having to enqueue a closure for the sole purpose of retaining a reference.