### PR TITLE
move some methods to a protocol extension

### DIFF
--- a/Source/deferred/result-extensions.swift
+++ b/Source/deferred/result-extensions.swift
@@ -24,3 +24,99 @@ extension Result where Failure == Never
     }
   }
 }
+
+public protocol ResultWrapper
+{
+  associatedtype Success
+  associatedtype Failure: Error
+
+  var result: Result<Success, Failure> { get }
+
+  func get() throws -> Success
+
+  var value: Success? { get }
+  var error: Failure? { get }
+}
+
+extension ResultWrapper
+{
+  /// Get this `Deferred`'s value, blocking if necessary until it becomes resolved.
+  ///
+  /// If the `Deferred` is resolved with a `Failure`, return nil.
+  ///
+  /// When called on a `Deferred` that is already resolved, this call is non-blocking.
+  ///
+  /// When called on a `Deferred` that is not resolved, this call blocks the executing thread.
+  ///
+  /// - returns: this `Deferred`'s resolved value, or `nil`
+
+  public var value: Success? {
+    if case .success(let value) = result { return value }
+    return nil
+  }
+
+  /// Get this `Deferred`'s error state, blocking if necessary until it becomes resolved.
+  ///
+  /// If the `Deferred` is resolved with a `Success`, return nil.
+  ///
+  /// When called on a `Deferred` that is already resolved, this call is non-blocking.
+  ///
+  /// When called on a `Deferred` that is not resolved, this call blocks the executing thread.
+  ///
+  /// - returns: this `Deferred`'s resolved error state, or `nil`
+
+  public var error: Failure? {
+    if case .failure(let error) = result { return error }
+    return nil
+  }
+
+  /// Get this `Deferred`'s value, blocking if necessary until it becomes resolved.
+  ///
+  /// If the `Deferred` is resolved with a `Failure`, that `Failure` is thrown.
+  ///
+  /// When called on a `Deferred` that is already resolved, this call is non-blocking.
+  ///
+  /// When called on a `Deferred` that is not resolved, this call blocks the executing thread.
+  ///
+  /// - returns: this `Deferred`'s resolved `Success`, or throws
+  /// - throws: this `Deferred`'s resolved `Failure` if it cannot return a `Success`
+
+  public func get() throws -> Success
+  {
+    return try result.get()
+  }
+}
+
+extension ResultWrapper where Failure == Never
+{
+  /// Get this `Deferred`'s value, blocking if necessary until it becomes resolved.
+  ///
+  /// When called on a `Deferred` that is already resolved, this call is non-blocking.
+  ///
+  /// When called on a `Deferred` that is not resolved, this call blocks the executing thread.
+  ///
+  /// - returns: this `Deferred`'s resolved `Success` value
+
+  public var value: Success {
+    switch result
+    {
+    case .success(let value): return value
+    }
+  }
+
+  /// Get this `Deferred`'s value, blocking if necessary until it becomes resolved.
+  ///
+  /// If the `Deferred` is resolved with a `Failure`, that `Failure` is thrown.
+  ///
+  /// When called on a `Deferred` that is already resolved, this call is non-blocking.
+  ///
+  /// When called on a `Deferred` that is not resolved, this call blocks the executing thread.
+  ///
+  /// - returns: this `Deferred`'s resolved `Success`, or throws
+  /// - throws: this `Deferred`'s resolved `Failure` if it cannot return a `Success`
+
+  public func get() -> Success
+  {
+    return value
+  }
+}

--- a/Tests/deferredTests/DeferredCombinationTests.swift
+++ b/Tests/deferredTests/DeferredCombinationTests.swift
@@ -165,7 +165,7 @@ class DeferredCombinationTimedTests: XCTestCase
       let inputs = (1...iterations).map { Deferred<Int, Never>(value: $0) }
       self.startMeasuring()
       let c = reduce(inputs, initial: 0, combine: +)
-      let v = try? c.get()
+      let v = c.get()
       XCTAssertEqual(v, iterations*(iterations+1)/2)
       self.stopMeasuring()
     }
@@ -185,7 +185,7 @@ class DeferredCombinationTimedTests: XCTestCase
           u in deferred.map { t in u+t }
         }
       }
-      let v = try? c.get()
+      let v = c.value
       XCTAssertEqual(v, iterations*(iterations+1)/2)
       self.stopMeasuring()
     }
@@ -199,8 +199,8 @@ class DeferredCombinationTimedTests: XCTestCase
       let inputs = (1...iterations).map { Deferred<Int, Never>(value: $0) }
       self.startMeasuring()
       let c = combine(inputs)
-      let v = try? c.get()
-      XCTAssertEqual(v?.count, iterations)
+      let v = c.value
+      XCTAssertEqual(v.count, iterations)
       self.stopMeasuring()
     }
   }

--- a/Tests/deferredTests/DeferredTimingTests.swift
+++ b/Tests/deferredTests/DeferredTimingTests.swift
@@ -35,7 +35,7 @@ class DeferredTimingTests: XCTestCase
 
       self.startMeasuring()
       trigger.resolve(value: (0, ref, ref))
-      let (iterations, tic, toc) = try! dt.get()
+      let (iterations, tic, toc) = dt.value
       self.stopMeasuring()
 
       let interval = toc.timeIntervalSince(tic)
@@ -61,7 +61,7 @@ class DeferredTimingTests: XCTestCase
       }
 
       let dt = start.map { start in Date().timeIntervalSince(start) }
-      let interval = try! dt.get()
+      let interval = dt.value
       self.stopMeasuring()
 
       // print("\(round(Double(interval*1e9)/Double(iterations))/1000) µs per notification")

--- a/Tests/deferredTests/ResolverTests.swift
+++ b/Tests/deferredTests/ResolverTests.swift
@@ -155,7 +155,7 @@ class ParallelTests: XCTestCase
     let count = 20
     let d = Deferred.inParallel(count: count, queue: q) { $0 }
     let c = combine(d)
-    let value = try c.get()
+    let value = c.value
     XCTAssertEqual(value.count, count)
   }
 


### PR DESCRIPTION
- this allows some function overloading based on the generic parameter.
- in particular, the `value` property and the `get()` function are now nicer for the never-fail case.