### PR TITLE
add initializers that synchronously run a closure

### DIFF
--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -58,6 +58,12 @@ class DeferredTests: XCTestCase
     XCTAssertEqual(d.state, .resolved)
   }
 
+  func testSynchronousInit()
+  {
+    let d1 = Deferred<Int, Cancellation>(notifyingAt: .current) { _ in }
+    XCTAssertEqual(d1.state, .executing)
+  }
+
   func testPeek()
   {
     let value = nzRandom()


### PR DESCRIPTION
- this is sometimes desirable, it turns out.