### PR TITLE
further improve the cancellation system again

### DIFF
--- a/Source/deferred/deferred-error.swift
+++ b/Source/deferred/deferred-error.swift
@@ -18,8 +18,6 @@ public enum Cancellation: Error, Equatable, Hashable
   public static func canceled() -> Cancellation { return .canceled("") }
   public static func timedOut() -> Cancellation { return .timedOut("") }
 #endif
-
-  case notSelected // not selected in a race between multiple deferreds
 }
 
 extension Cancellation: CustomStringConvertible
@@ -35,8 +33,6 @@ extension Cancellation: CustomStringConvertible
       return message.isEmpty ?
         "Deferred operation timed out before a result became available" :
         "Deferred operation timed out: \(message)"
-    case .notSelected:
-      return "Deferred was canceled when another got resolved more quickly"
     }
   }
 }

--- a/Source/deferred/deferred-error.swift
+++ b/Source/deferred/deferred-error.swift
@@ -27,12 +27,10 @@ extension Cancellation: CustomStringConvertible
     {
     case .canceled(let message):
       return message.isEmpty ?
-        "Deferred was canceled before a result became available" :
-        "Deferred canceled: \(message)"
+        "canceled" : "canceled: \(message)"
     case .timedOut(let message):
       return message.isEmpty ?
-        "Deferred operation timed out before a result became available" :
-        "Deferred operation timed out: \(message)"
+        "timed out" : "timed out: \(message)"
     }
   }
 }

--- a/Source/deferred/deferred-first.swift
+++ b/Source/deferred/deferred-first.swift
@@ -570,9 +570,9 @@ extension Deferred
     if Cancellation.notSelected is Failure
     {
       if let s = self as? Deferred<Success, Cancellation>
-      { s.cancel(.notSelected) }
+      { s.cancel(Cancellation.notSelected) }
       else if let s = self as? Deferred<Success, Error>
-      { s.cancel(.notSelected) }
+      { s.cancel(Cancellation.notSelected) }
     }
   }
 }

--- a/Source/deferred/deferred-timeout.swift
+++ b/Source/deferred/deferred-timeout.swift
@@ -60,16 +60,16 @@ extension Deferred
     else
     { broadened = self.withAnyError }
 
-    if convertCancellation(.timedOut(reason)) != nil
+    if let error = convertCancellation(Cancellation.timedOut(reason))
     {
       if deadline < .now()
       {
-        self.cancel(.timedOut(reason))
+        self.cancel(error)
       }
       else if deadline != .distantFuture
       {
         let queue = DispatchQueue(label: "timeout", qos: qos)
-        queue.asyncAfter(deadline: deadline) { [weak self] in self?.cancel(.timedOut(reason)) }
+        queue.asyncAfter(deadline: deadline) { [weak self] in self?.cancel(error) }
       }
       return broadened
     }

--- a/Source/deferred/deferred-timeout.swift
+++ b/Source/deferred/deferred-timeout.swift
@@ -76,12 +76,12 @@ extension Deferred
 
     if deadline < .now()
     {
-      broadened.cancel(.timedOut(reason))
+      broadened.cancel(Cancellation.timedOut(reason))
     }
     else if deadline != .distantFuture
     {
       let queue = DispatchQueue(label: "timeout", qos: qos)
-      queue.asyncAfter(deadline: deadline) { [weak broadened] in broadened?.cancel(.timedOut(reason)) }
+      queue.asyncAfter(deadline: deadline) { [weak broadened] in broadened?.cancel(Cancellation.timedOut(reason)) }
     }
     return broadened
   }
@@ -132,12 +132,12 @@ extension Deferred where Failure == Cancellation
 
     if deadline < .now()
     {
-      cancel(.timedOut(reason))
+      cancel(Cancellation.timedOut(reason))
     }
     else if deadline != .distantFuture
     {
       let queue = DispatchQueue(label: "timeout", qos: qos)
-      queue.asyncAfter(deadline: deadline) { [weak self] in self?.cancel(.timedOut(reason)) }
+      queue.asyncAfter(deadline: deadline) { [weak self] in self?.cancel(Cancellation.timedOut(reason)) }
     }
     return self
   }

--- a/Source/deferred/deferred-timeout.swift
+++ b/Source/deferred/deferred-timeout.swift
@@ -60,28 +60,29 @@ extension Deferred
     else
     { broadened = self.withAnyError }
 
-    if let error = convertCancellation(Cancellation.timedOut(reason))
+    let timedOut = Cancellation.timedOut(reason)
+    if let timedOut = convertCancellation(timedOut)
     {
       if deadline < .now()
       {
-        self.cancel(error)
+        self.cancel(timedOut)
       }
       else if deadline != .distantFuture
       {
         let queue = DispatchQueue(label: "timeout", qos: qos)
-        queue.asyncAfter(deadline: deadline) { [weak self] in self?.cancel(error) }
+        queue.asyncAfter(deadline: deadline) { [weak self] in self?.cancel(timedOut) }
       }
       return broadened
     }
 
     if deadline < .now()
     {
-      broadened.cancel(Cancellation.timedOut(reason))
+      broadened.cancel(timedOut)
     }
     else if deadline != .distantFuture
     {
       let queue = DispatchQueue(label: "timeout", qos: qos)
-      queue.asyncAfter(deadline: deadline) { [weak broadened] in broadened?.cancel(Cancellation.timedOut(reason)) }
+      queue.asyncAfter(deadline: deadline) { [weak broadened] in broadened?.cancel(timedOut) }
     }
     return broadened
   }
@@ -130,14 +131,15 @@ extension Deferred where Failure == Cancellation
   {
     if self.isResolved { return self }
 
+    let timedOut = Cancellation.timedOut(reason)
     if deadline < .now()
     {
-      cancel(Cancellation.timedOut(reason))
+      cancel(timedOut)
     }
     else if deadline != .distantFuture
     {
       let queue = DispatchQueue(label: "timeout", qos: qos)
-      queue.asyncAfter(deadline: deadline) { [weak self] in self?.cancel(Cancellation.timedOut(reason)) }
+      queue.asyncAfter(deadline: deadline) { [weak self] in self?.cancel(timedOut) }
     }
     return self
   }

--- a/Source/deferred/deferred.swift
+++ b/Source/deferred/deferred.swift
@@ -222,9 +222,9 @@ open class Deferred<Success, Failure: Error>
   ///
   /// - returns: a converted `Failure` instance, or `nil` if cancellation will fail.
 
-  open func convertCancellation(_ error: Cancellation) -> Failure?
+  open func convertCancellation<E: Error>(_ error: E) -> Failure?
   {
-    return (error as? Failure)
+    return (error as? Cancellation) as? Failure
   }
 
   /// Attempt to cancel this `Deferred`.
@@ -234,7 +234,7 @@ open class Deferred<Success, Failure: Error>
   ///
   /// - parameter error: the Cancellation error to use in resolving this `Deferred`
 
-  open func cancel(_ error: Cancellation)
+  open func cancel<E: Error>(_ error: E)
   {
     if let error = convertCancellation(error)
     {

--- a/Source/deferred/deferred.swift
+++ b/Source/deferred/deferred.swift
@@ -438,7 +438,7 @@ extension Deferred where Failure == Cancellation
 
   public func cancel(_ reason: String = "")
   {
-    cancel(.canceled(reason))
+    cancel(Cancellation.canceled(reason))
   }
 }
 
@@ -456,7 +456,7 @@ extension Deferred where Failure == Error
 
   public func cancel(_ reason: String = "")
   {
-    cancel(.canceled(reason))
+    cancel(Cancellation.canceled(reason))
   }
 }
 

--- a/Tests/deferredTests/DeferredTests.swift
+++ b/Tests/deferredTests/DeferredTests.swift
@@ -247,7 +247,6 @@ class DeferredTests: XCTestCase
       .canceled(customMessage),
       .timedOut(""),
       .timedOut(customMessage),
-      .notSelected
     ]
 
     let cancellationStrings = cancellations.map(String.init(describing: ))


### PR DESCRIPTION
- eliminate the `.notSelected` case of `Cancellation`, in favor of `.timedOut`
  (it is a form of timeout, just not strictly time-based.) This error case was previously used in the
  various `firstValue` and `firstResolved` functions.

- improve flexibility of the cancellation system for subclasses.
   For example, an subclass of `Deferred` that implements an HTTP loader can support cancellation while using `URLError` as its error type. (This requires subclassing.)