### PR TITLE
Improve queue handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ jobs:
       env: SWIFT=5.2.4
 
     - os: osx
-      osx_image: xcode12.1
-      env: SWIFT=5.3
+      osx_image: xcode12.2
+      env: SWIFT=5.3.1
 
     - os: linux
       env: SWIFT=5.0.3
@@ -30,7 +30,7 @@ jobs:
       env: SWIFT=5.2.5
 
     - os: linux
-      env: SWIFT=5.3
+      env: SWIFT=5.3.1
 
 before_install:
   - clang --version

--- a/Source/deferred/deferred-first.swift
+++ b/Source/deferred/deferred-first.swift
@@ -47,7 +47,7 @@ public func firstValue<Success, Failure, C: Collection>(_ deferreds: C, qos: Dis
                                                         cancelOthers: Bool = false) -> Deferred<Success, Failure>?
   where C.Element: Deferred<Success, Failure>
 {
-  let queue = DispatchQueue(label: "first-collection", qos: qos)
+  let queue = DispatchQueue(label: "first-deferred", qos: qos, target: .global(qos: qos.qosClass))
   return firstValue(deferreds, queue: queue, cancelOthers: cancelOthers)
 }
 
@@ -144,7 +144,7 @@ public func firstValue<Success, Failure, S: Sequence>(_ deferreds: S, qos: Dispa
                                                       cancelOthers: Bool = false) -> Deferred<Success, Failure>?
   where S.Element: Deferred<Success, Failure>
 {
-  let queue = DispatchQueue(label: "first-sequence", qos: qos)
+  let queue = DispatchQueue(label: "first-deferred", qos: qos, target: .global(qos: qos.qosClass))
   return firstValue(deferreds, queue: queue, cancelOthers: cancelOthers)
 }
 
@@ -222,7 +222,7 @@ public func firstResolved<Success, Failure, C>(_ deferreds: C, qos: DispatchQoS 
                                                cancelOthers: Bool = false) -> Deferred<Success, Failure>?
   where C: Collection, C.Element: Deferred<Success, Failure>
 {
-  let queue = DispatchQueue(label: "first-collection", qos: qos)
+  let queue = DispatchQueue(label: "first-deferred", qos: qos, target: .global(qos: qos.qosClass))
   return firstResolved(deferreds, queue: queue, cancelOthers: cancelOthers)
 }
 
@@ -274,7 +274,7 @@ public func firstResolved<Success, Failure, S: Sequence>(_ deferreds: S, qos: Di
                                                          cancelOthers: Bool = false) -> Deferred<Success, Failure>?
   where S.Element: Deferred<Success, Failure>
 {
-  let queue = DispatchQueue(label: "first-sequence", qos: qos)
+  let queue = DispatchQueue(label: "first-deferred", qos: qos, target: .global(qos: qos.qosClass))
   return firstResolved(deferreds, queue: queue, cancelOthers: cancelOthers)
 }
 
@@ -460,7 +460,8 @@ public func firstValue<T1, F1, T2, F2>(_ d1: Deferred<T1, F1>,
   -> (Deferred<T1, Error>, Deferred<T2, Error>)
 {
   // find which input first gets a value
-  let queue = DispatchQueue(label: "select", qos: .current)
+  let qos = DispatchQoS.current
+  let queue = DispatchQueue(label: "first-deferred", qos: qos, target: .global(qos: qos.qosClass))
   let timeoutMessage = "too slow in \(#function)"
   let selected = Deferred<ObjectIdentifier, Invalidation>(queue: queue) {
     resolver in
@@ -497,7 +498,8 @@ public func firstValue<T1, F1, T2, F2, T3, F3>(_ d1: Deferred<T1, F1>,
   -> (Deferred<T1, Error>, Deferred<T2, Error>, Deferred<T3, Error>)
 {
   // find which input first gets a value
-  let queue = DispatchQueue(label: "select", qos: .current)
+  let qos = DispatchQoS.current
+  let queue = DispatchQueue(label: "first-deferred", qos: qos, target: .global(qos: qos.qosClass))
   let timeoutMessage = "too slow in \(#function)"
   let selected = Deferred<ObjectIdentifier, Invalidation>() {
     resolver in
@@ -538,7 +540,8 @@ public func firstValue<T1, F1, T2, F2, T3, F3, T4, F4>(_ d1: Deferred<T1, F1>,
   -> (Deferred<T1, Error>, Deferred<T2, Error>, Deferred<T3, Error>, Deferred<T4, Error>)
 {
   // find which input first gets a value
-  let queue = DispatchQueue(label: "select", qos: .current)
+  let qos = DispatchQoS.current
+  let queue = DispatchQueue(label: "first-deferred", qos: qos, target: .global(qos: qos.qosClass))
   let timeoutMessage = "too slow in \(#function)"
   let selected = Deferred<ObjectIdentifier, Invalidation>() {
     resolver in

--- a/Source/deferred/deferred-parallelize.swift
+++ b/Source/deferred/deferred-parallelize.swift
@@ -111,7 +111,11 @@ extension Collection
                                    task: @escaping (_ element: Self.Element) throws -> Success) -> [Deferred<Success, Error>]
   {
     let count = self.count
-    let pairs = (0..<count).map { _ in Deferred<Success, Error>.CreatePair(queue: queue) }
+    let pairs = (0..<count).map {
+      Deferred<Success, Error>.CreatePair(
+        queue: DispatchQueue(label: "deferred-map-\($0)", qos: queue.qos, target: queue)
+      )
+    }
     let resolvers = pairs.map { $0.0 }
 
     queue.async {
@@ -143,7 +147,11 @@ extension Collection
                                    task: @escaping (_ element: Self.Element) -> Success) -> [Deferred<Success, Never>]
   {
     let count = self.count
-    let pairs = (0..<count).map { _ in Deferred<Success, Never>.CreatePair(queue: queue) }
+    let pairs = (0..<count).map {
+      Deferred<Success, Never>.CreatePair(
+        queue: DispatchQueue(label: "deferred-map-\($0)", qos: queue.qos, target: queue)
+      )
+    }
     let resolvers = pairs.map { $0.0 }
 
     queue.async {

--- a/Source/deferred/deferred-parallelize.swift
+++ b/Source/deferred/deferred-parallelize.swift
@@ -82,7 +82,7 @@ extension Collection
   public func deferredMap<Success>(qos: DispatchQoS = .current,
                                    task: @escaping (_ element: Self.Element) throws -> Success) -> [Deferred<Success, Error>]
   {
-    let queue = DispatchQueue(label: "deferred-map", qos: qos)
+    let queue = DispatchQueue(label: "parallel-deferred", qos: qos, attributes: .concurrent, target: .global(qos: qos.qosClass))
     return deferredMap(queue: queue, task: task)
   }
 
@@ -96,7 +96,7 @@ extension Collection
   public func deferredMap<Success>(qos: DispatchQoS = .current,
                                    task: @escaping (_ element: Self.Element) -> Success) -> [Deferred<Success, Never>]
   {
-    let queue = DispatchQueue(label: "deferred-map", qos: qos)
+    let queue = DispatchQueue(label: "parallel-deferred", qos: qos, attributes: .concurrent, target: .global(qos: qos.qosClass))
     return deferredMap(queue: queue, task: task)
   }
 
@@ -113,7 +113,7 @@ extension Collection
     let count = self.count
     let pairs = (0..<count).map {
       Deferred<Success, Error>.CreatePair(
-        queue: DispatchQueue(label: "deferred-map-\($0)", qos: queue.qos, target: queue)
+        queue: DispatchQueue(label: "\(queue.label)-\($0)", qos: queue.qos, target: queue)
       )
     }
     let resolvers = pairs.map { $0.0 }
@@ -149,7 +149,7 @@ extension Collection
     let count = self.count
     let pairs = (0..<count).map {
       Deferred<Success, Never>.CreatePair(
-        queue: DispatchQueue(label: "deferred-map-\($0)", qos: queue.qos, target: queue)
+        queue: DispatchQueue(label: "\(queue.label)-\($0)", qos: queue.qos, target: queue)
       )
     }
     let resolvers = pairs.map { $0.0 }

--- a/Source/deferred/deferred-timeout.swift
+++ b/Source/deferred/deferred-timeout.swift
@@ -69,7 +69,7 @@ extension Deferred
       }
       else if deadline != .distantFuture
       {
-        let queue = DispatchQueue(label: "timeout", qos: qos)
+        let queue = DispatchQueue.global(qos: qos.qosClass)
         queue.asyncAfter(deadline: deadline) { [weak self] in self?.cancel(timedOut) }
       }
       return broadened
@@ -81,7 +81,7 @@ extension Deferred
     }
     else if deadline != .distantFuture
     {
-      let queue = DispatchQueue(label: "timeout", qos: qos)
+      let queue = DispatchQueue.global(qos: qos.qosClass)
       queue.asyncAfter(deadline: deadline) { [weak broadened] in broadened?.cancel(timedOut) }
     }
     return broadened
@@ -138,7 +138,7 @@ extension Deferred where Failure == Cancellation
     }
     else if deadline != .distantFuture
     {
-      let queue = DispatchQueue(label: "timeout", qos: qos)
+      let queue = DispatchQueue.global(qos: qos.qosClass)
       queue.asyncAfter(deadline: deadline) { [weak self] in self?.cancel(timedOut) }
     }
     return self

--- a/Source/deferred/deferred.swift
+++ b/Source/deferred/deferred.swift
@@ -107,7 +107,7 @@ open class Deferred<Success, Failure: Error>
 
   public convenience init(qos: DispatchQoS = .current, task: @escaping (Resolver<Success, Failure>) -> Void)
   {
-    let queue = DispatchQueue(label: "deferred", qos: qos)
+    let queue = DispatchQueue(label: "deferred", qos: qos, target: .global(qos: qos.qosClass))
     self.init(queue: queue, task: task)
   }
 
@@ -120,7 +120,7 @@ open class Deferred<Success, Failure: Error>
 
   public convenience init(notifyingAt qos: DispatchQoS, synchronous task: (Resolver<Success, Failure>) -> Void)
   {
-    let queue = DispatchQueue(label: "deferred", qos: qos)
+    let queue = DispatchQueue(label: "deferred", qos: qos, target: .global(qos: qos.qosClass))
     self.init(notifyingOn: queue, synchronous: task)
   }
 
@@ -131,7 +131,7 @@ open class Deferred<Success, Failure: Error>
 
   public convenience init(qos: DispatchQoS = .current, result: Result<Success, Failure>)
   {
-    let queue = DispatchQueue(label: "deferred", qos: qos)
+    let queue = DispatchQueue(label: "deferred", qos: qos, target: .global(qos: qos.qosClass))
     self.init(queue: queue, result: result)
   }
 
@@ -142,7 +142,7 @@ open class Deferred<Success, Failure: Error>
 
   public convenience init(qos: DispatchQoS = .current, value: Success)
   {
-    let queue = DispatchQueue(label: "deferred", qos: qos)
+    let queue = DispatchQueue(label: "deferred", qos: qos, target: .global(qos: qos.qosClass))
     self.init(queue: queue, value: value)
   }
 
@@ -163,7 +163,7 @@ open class Deferred<Success, Failure: Error>
 
   public convenience init(qos: DispatchQoS = .current, error: Failure)
   {
-    let queue = DispatchQueue(label: "deferred", qos: qos)
+    let queue = DispatchQueue(label: "deferred", qos: qos, target: .global(qos: qos.qosClass))
     self.init(queue: queue, error: error)
   }
 
@@ -401,7 +401,7 @@ extension Deferred where Failure == Error
 
   public convenience init(qos: DispatchQoS = .current, task: @escaping () throws -> Success)
   {
-    let queue = DispatchQueue(label: "deferred", qos: qos)
+    let queue = DispatchQueue(label: "deferred", qos: qos, target: .global(qos: qos.qosClass))
     self.init(queue: queue, task: task)
   }
 }
@@ -425,7 +425,7 @@ extension Deferred where Failure == Never
 
   public convenience init(qos: DispatchQoS = .current, task: @escaping () -> Success)
   {
-    let queue = DispatchQueue(label: "deferred", qos: qos)
+    let queue = DispatchQueue(label: "deferred", qos: qos, target: .global(qos: qos.qosClass))
     self.init(queue: queue, task: task)
   }
 }
@@ -719,7 +719,7 @@ extension Deferred
 
   public static func CreatePair(qos: DispatchQoS = .current) -> (resolver: Resolver<Success, Failure>, deferred: Deferred<Success, Failure>)
   {
-    let queue = DispatchQueue(label: "tbd", qos: qos)
+    let queue = DispatchQueue(label: "deferred", qos: qos, target: .global(qos: qos.qosClass))
     return CreatePair(queue: queue)
   }
 }

--- a/Tests/deferredTests/DeferredExtrasTests.swift
+++ b/Tests/deferredTests/DeferredExtrasTests.swift
@@ -176,7 +176,7 @@ class DeferredExtrasTests: XCTestCase
   func testRetrying2()
   {
     let retries = 5
-    let queue = DispatchQueue(label: "test", qos: .background)
+    let queue = DispatchQueue(label: #function, qos: .background)
 
     var counter = retries+retries-1
     func transform() throws -> Int

--- a/Tests/deferredTests/DeferredExtrasTests.swift
+++ b/Tests/deferredTests/DeferredExtrasTests.swift
@@ -333,7 +333,7 @@ class DeferredExtrasTests: XCTestCase
     let r1 = nzRandom()
     let r2 = nzRandom()
 
-    let t1 = Deferred<Int, Never>(value: r1).enqueuing(at: .utility, serially: false)
+    let t1 = Deferred<Int, Never>(value: r1).enqueuing(at: .utility)
     XCTAssertEqual(t1.value, r1)
 
     let t2 = Deferred<Int, Never>(value: r2).delay(seconds: 0.01).enqueuing(at: .userInitiated)
@@ -344,7 +344,7 @@ class DeferredExtrasTests: XCTestCase
   {
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
     let q = DispatchQueue.global(qos: .utility)
-    let qb = Deferred(queue: q, task: { qos_class_self() }).enqueuing(at: .background, serially: false)
+    let qb = Deferred(queue: q, task: { qos_class_self() }).enqueuing(at: .background)
     // Verify that the block's QOS was adjusted and is different from the queue's
     XCTAssertEqual(qb.value, QOS_CLASS_UTILITY)
     XCTAssertEqual(qb.qos, DispatchQoS.background)
@@ -360,7 +360,7 @@ class DeferredExtrasTests: XCTestCase
     }
 
     let e2 = expectation(description: "e2")
-    let q2 = qb.enqueuing(at: .background, serially: true)
+    let q2 = qb.enqueuing(at: .background)
     q2.notify { _ in e2.fulfill() }
 
     let e3 = expectation(description: "e3")

--- a/Tests/deferredTests/DeferredTimingTests.swift
+++ b/Tests/deferredTests/DeferredTimingTests.swift
@@ -49,7 +49,7 @@ class DeferredTimingTests: XCTestCase
     let iterations = propagationTestCount
 
     measureMetrics(XCTestCase.defaultPerformanceMetrics, automaticallyStartMeasuring: false) {
-      let start = Deferred<Date, Never>(queue: DispatchQueue(label: "", qos: .userInitiated)) {
+      let start = Deferred<Date, Never>(queue: DispatchQueue(label: #function, qos: .userInitiated)) {
         start in
         for _ in 0..<iterations
         {

--- a/Tests/deferredTests/DeletionTests.swift
+++ b/Tests/deferredTests/DeletionTests.swift
@@ -36,7 +36,7 @@ class DeletionTests: XCTestCase
     let witness: Deferred<Void, Never>
     let e = expectation(description: "deallocation delay")
     do {
-      let queue = DispatchQueue(label: "\(#function)")
+      let queue = DispatchQueue(label: #function)
       let delayed = Deferred<Void, Never>(queue: queue, value: ()).delay(.milliseconds(50))
       _ = delayed.map { XCTFail("a value no one waits for should not be computed") }
       witness = delayed.map { e.fulfill() }

--- a/Tests/deferredTests/ResolverTests.swift
+++ b/Tests/deferredTests/ResolverTests.swift
@@ -157,7 +157,7 @@ class ParallelTests: XCTestCase
   {
     // Verify that "accidentally" passing a serial queue to inParallel doesn't cause a deadlock
 
-    let q = DispatchQueue(label: "test1", qos: .utility)
+    let q = DispatchQueue(label: #function, qos: .utility)
 
     let count = 20
     let d = Deferred.inParallel(count: count, queue: q) { $0 }

--- a/Tests/deferredTests/ResolverTests.swift
+++ b/Tests/deferredTests/ResolverTests.swift
@@ -88,14 +88,22 @@ class ResolverTests: XCTestCase
 
   func testNotify()
   {
-    let (r, d) = Deferred<Int, Never>.CreatePair()
+    var (r, d): (Resolver<Int, Never>, Deferred<Int, Never>?) = {
+      let (r, d) = Deferred<Int, Never>.CreatePair()
+      return (r, Optional(d))
+    }()
 
     let e = expectation(description: #function)
     r.notify { e.fulfill() }
 
     r.resolve(value: Int.random(in: 1..<10))
     waitForExpectations(timeout: 0.1)
-    XCTAssertNotNil(d.value)
+    XCTAssertNotNil(d?.value)
+
+    d = nil
+    let f = expectation(description: #function + "-2")
+    r.notify { f.fulfill() }
+    waitForExpectations(timeout: 0.1)
   }
 
   func testNeverResolved()


### PR DESCRIPTION
- all queue creation actions now have a target queue
- occasionally and appropriately use concurrent queues
- improve queue labelling